### PR TITLE
サンプルデモのtypoを修正しました。

### DIFF
--- a/sample/sample_result_oneway.html
+++ b/sample/sample_result_oneway.html
@@ -51,7 +51,7 @@
     <!-- 金額切り替えボタン -->
     <div class="exp_sample_btn_area">
         <input class="exp_sample_btn" type="button" value="片道運賃" onClick="Javascript:resultApp.setPriceType(resultApp.PRICE_ONEWAY);">
-        <input class="exp_sample_btn" type="button" value="片道運賃" onClick="Javascript:resultApp.setPriceType(resultApp.PRICE_ROUND);">
+        <input class="exp_sample_btn" type="button" value="往復運賃" onClick="Javascript:resultApp.setPriceType(resultApp.PRICE_ROUND);">
         <input class="exp_sample_btn" type="button" value="定期金額" onClick="Javascript:resultApp.setPriceType(resultApp.PRICE_TEIKI);">
     </div>
 


### PR DESCRIPTION
### 概要
 * Webサービスサンプルデモのボタン表示にtypoがあったため修正しました。

### 修正内容
 * 「往復運賃」と表示されるべきボタンが片道運賃と表示されていたのを修正しました。

### 備考
 * `master` ブランチへのプルリクではなく、GitHub Pages( `gh-pages` ブランチ)に対するプルリクになります。