### PR TITLE
経路探索に使用する値を、駅名称ではなく駅コードに変更しました。

### DIFF
--- a/sample/sample.html
+++ b/sample/sample.html
@@ -119,11 +119,11 @@ function searchRun(teikiFlag){
     stationApp3.closeStationList();
     // 発着地リストを作成
     var viaList="";
-    viaList += stationApp1.getStation();
+    viaList += stationApp1.getStationCode();
     if(stationApp3.getStation() != ""){
-      viaList += ":"+ stationApp3.getStation();
+      viaList += ":"+ stationApp3.getStationCode();
     }
-    viaList += ":"+ stationApp2.getStation();
+    viaList += ":"+ stationApp2.getStationCode();
     // 経路表示パーツ#1の場合
     searchWord +="viaList="+viaList;
     // 探索種別
@@ -172,11 +172,11 @@ function searchTeiki(){
     stationApp3.closeStationList();
     // 発着地リストを作成
     var viaList="";
-    viaList += stationApp1.getStation();
+    viaList += stationApp1.getStationCode();
     if(stationApp3.getStation() != ""){
-      viaList += ":"+ stationApp3.getStation();
+      viaList += ":"+ stationApp3.getStationCode();
     }
-    viaList += ":"+ stationApp2.getStation();
+    viaList += ":"+ stationApp2.getStationCode();
     // 経路表示パーツ#1の場合
     searchWord +="viaList="+viaList;
     // 探索種別
@@ -286,4 +286,3 @@ function result(isSuccess){
 
 </body>
 </html>
-


### PR DESCRIPTION
経路探索APIで駅を指定する場合に、
駅名称ではなく駅コードを利用するように変更しました。

※駅すぱあとwebサービスでは、保存を前提として利用する場合に
不変である駅コードを利用することを推奨しています。
http://docs.ekispert.com/v1/dictionary/station-code/