### PR TITLE
日付入力パーツのカレンダーで、月末日を指定した際に月移動がスキップされるケースがあったため修正しました。

### DIFF
--- a/expGuiDateTime/expGuiDateTime.js
+++ b/expGuiDateTime/expGuiDateTime.js
@@ -327,6 +327,9 @@ var expGuiDateTime = function (pObject, config) {
                 c_month = 1;
             }
         }
+
+        // 存在しない日付が指定されるのを防ぐため、カレンダー移動時には日付を1日に固定する
+        c_date = 1;
         document.getElementById(baseId + ':c_table').innerHTML = getCalendarTable(c_year, c_month, c_date);
         document.getElementById(baseId + ':calendar').style.display = "block";
 


### PR DESCRIPTION
## 概要
 * 日付入力パーツ( `expGuiDateTime` )のカレンダーで、月末日を指定した際に月移動がスキップされるケースがあったため修正しました。
 * 例えば、5/31を選択した状態でカレンダーを6月に移動すると、6/31(存在しない日付)が設定されます。
   * JavaScriptのDateオブジェクトは6/31を7/1と解釈してカレンダーに設定するため、月移動が5月→7月となり、6月のカレンダーがスキップされたような動作になります。

## 修正内容
 * カレンダーの移動時には、日付を1日に設定するようにしました。