### PR TITLE
特定の経路における探索結果で座席種別が変更できなくなる不具合を修正しました。

### DIFF
--- a/expGuiCourse/expGuiCourse.js
+++ b/expGuiCourse/expGuiCourse.js
@@ -3172,13 +3172,11 @@ var expGuiCourse = function (pObject, config) {
                 chargeList.push(parseInt(document.getElementById(baseId + ':charge:' + selectNo + ':' + (i + 1)).value));
             }
             // 探索された経路がひとつの場合はundefinedを含んだidになるので、その可能性を考慮した判定を行う。
-if (! document.getElementById('check01').checked) {
             if (document.getElementById(baseId + ':chargeSelect:undefined:' + (i + 1))) {
                 chargeList.push(parseInt(document.getElementById(baseId + ':chargeSelect:undefined:' + (i + 1)).options.item(document.getElementById(baseId + ':chargeSelect:' + selectNo + ':' + (i + 1)).selectedIndex).value));
             } else if (document.getElementById(baseId + ':charge:undefined:' + (i + 1))) {
                 chargeList.push(parseInt(document.getElementById(baseId + ':charge:undefined:' + (i + 1)).value));
             }
-}
             // 定期の選択リスト作成
             if (document.getElementById(baseId + ':teikiSelect:' + selectNo + ':' + (i + 1))) {
                 if (document.getElementById(baseId + ':teikiKind:' + selectNo + ':' + (i + 1)).value == "vehicle") {


### PR DESCRIPTION
## 概要
お客様からの問い合わせで判明した、以下の不具合への対応になります。
 * GUIサンプルで特定経路(例： `本庄早稲田駅` → `長野駅` )の経路探索結果において、座席種別が変更できない不具合があったため修正しました。

## 不具合の原因
 * API側には正しく値を返しており、原因はGUI側にありました。
 * GUI側では経路探索の結果をパースし、座席種別のリストUIで使用するデータを内部的に作成します。データはDOM要素のidで特定する仕組みになっていますが、生成したid文字列にundefinedを含む場合にデータの紐づけが行えない状態になっていました。

## 修正内容
 * DOM要素のidがundefinedを含んでいる場合でも要素自体は生成されているため、そのid名でもデータのマッチングを行うようにする処理を追加しました。
