### PR TITLE
新幹線eチケットの探索条件と表示に対応しました。

### DIFF
--- a/expGuiCondition/expCss/expGuiCondition.css
+++ b/expGuiCondition/expCss/expGuiCondition.css
@@ -100,7 +100,7 @@
     padding-top: 8px;
     padding-bottom: 10px;
     padding-left: 11px;
-    width: 8em;
+    width: 9.5em;
     font-weight: bold;
     font-size: 1.1em;
 }
@@ -110,6 +110,7 @@
     padding-top: 12px;
     text-align: left;
     font-size: 1em;
+    margin-left: 20px;
 }
 .expGuiConditionPc .exp_conditionDetail .exp_conditionTable .exp_conditionItemList .exp_conditionValue label {
     padding-right: 18px;
@@ -865,7 +866,7 @@
 
 /* iPhone 5/SE より画面幅が小さい場合 */
 @media screen and (max-width: 320px) {
-    .exp_conditionValue>select {
+    .exp_conditionValue select {
         width: 120px !important;
     }
 }

--- a/expGuiCondition/expCss/expGuiCondition.css
+++ b/expGuiCondition/expCss/expGuiCondition.css
@@ -866,6 +866,6 @@
 /* iPhone 5/SE より画面幅が小さい場合 */
 @media screen and (max-width: 320px) {
     .exp_conditionValue>select {
-        width: 110px !important;
+        width: 120px !important;
     }
 }

--- a/expGuiCondition/expCss/expGuiCondition.css
+++ b/expGuiCondition/expCss/expGuiCondition.css
@@ -855,3 +855,17 @@
     text-shadow: 0px 1px 1px rgba(255,255,255,1);
     font-weight: bold;
 }
+
+/* iPhone 6/7/8/X より画面幅が小さい場合 */
+@media screen and (max-width: 380px) {
+    .exp_conditionValue {
+        margin-left: 0;
+    }
+}
+
+/* iPhone 5/SE より画面幅が小さい場合 */
+@media screen and (max-width: 320px) {
+    .exp_conditionValue>select {
+        width: 110px !important;
+    }
+}

--- a/expGuiCondition/expGuiCondition.js
+++ b/expGuiCondition/expGuiCondition.js
@@ -950,24 +950,24 @@ var expGuiCondition = function (pObject, config) {
                 } else if (eventIdList[1].toLowerCase() == String("studentDiscount").toLowerCase()) {
                     // 学割乗車券とエクスプレス予約は排他
                     if (getValue("studentDiscount") == "true" && getValue("JRReservation") != "none") {
-                        setValue("JRReservation", "none");
+                        setValue("studentDiscount", "false");
                         alert("学割乗車券とエクスプレス予約を同時に有効にすることはできません。")
                     }
                     // 学割乗車券と新幹線eチケットは排他
                     if (getValue("studentDiscount") == "true" && getValue("shinkansenETicket") != "none") {
-                        setValue("shinkansenETicket", "none");
+                        setValue("studentDiscount", "false");
                         alert("学割乗車券と新幹線eチケットを同時に有効にすることはできません。")
                     }
                 } else if (eventIdList[1].toLowerCase() == String("JRReservation").toLowerCase()) {
                     // 学割乗車券とエクスプレス予約は排他
                     if (getValue("JRReservation") != "none" && getValue("studentDiscount") == "true") {
-                        setValue("studentDiscount", "false");
+                        setValue("JRReservation", "none");
                         alert("学割乗車券とエクスプレス予約を同時に有効にすることはできません。")
                     }
                 } else if (eventIdList[1].toLowerCase() == String("shinkansenETicket").toLowerCase()) {
                     // 学割乗車券と新幹線eチケットは排他
                     if (getValue("shinkansenETicket") != "none" && getValue("studentDiscount") == "true") {
-                        setValue("studentDiscount", "false");
+                        setValue("shinkansenETicket", "none");
                         alert("学割乗車券と新幹線eチケットを同時に有効にすることはできません。")
                     }
                 }

--- a/expGuiCondition/expGuiCondition.js
+++ b/expGuiCondition/expGuiCondition.js
@@ -199,15 +199,15 @@ var expGuiCondition = function (pObject, config) {
         var tmpOption = new Array("計算する", "計算しない");
         var tmpValue = new Array("true", "false");
         tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
-        // エクスプレス予約サービス
+        // エクスプレス予約
         var conditionId = "JRReservation";
-        var conditionLabel = "エクスプレス予約サービス";
+        var conditionLabel = "エクスプレス予約";
         var tmpOption = new Array("適用しない","ＥＸ予約", "ＥＸ予約(ｅ特急券)", "ＥＸ予約(ＥＸ早特)", "ＥＸ予約(ＥＸ早特２１)", "ＥＸ予約(ＥＸグリーン早特)", "スマートＥＸ", "スマートＥＸ(ＥＸ早特)", "スマートＥＸ(ＥＸ早特２１)", "スマートＥＸ(ＥＸグリーン早特)");
         var tmpValue = new Array("none", "exYoyaku", "exETokkyu", "exHayatoku", "exHayatoku21", "exGreenHayatoku", "smartEx", "smartExHayatoku", "smartExHayatoku21", "smartExGreenHayatoku");
         tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
         // 新幹線eチケット
         var conditionId = "shinkansenETicket";
-        var conditionLabel = "新幹線eチケットサービス";
+        var conditionLabel = "新幹線eチケット";
         var tmpOption = new Array("適用しない","新幹線eチケット");
         var tmpValue = new Array("none", "eTicket");
         tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
@@ -566,7 +566,7 @@ var expGuiCondition = function (pObject, config) {
         // 定期種別初期値
         buffer += outConditionRadio("teikiKind", "greenSelect");
         buffer += outSeparator("teikiKind");
-        // エクスプレス予約サービス
+        // エクスプレス予約
         if (agent == 1 || agent == 2) {
             buffer += outConditionSelect("JRReservation");
         } else if (agent == 3) {
@@ -750,8 +750,8 @@ var expGuiCondition = function (pObject, config) {
         buffer += outConditionSelect("studentDiscount", "whiteSelect"); // 学割乗車券
         buffer += outConditionSelect("teikiKind", "greenSelect"); // 定期種別初期値
         buffer += outConditionSelect("JRSeasonalRate", "whiteSelect"); // JR季節料金
-        buffer += outConditionSelect("JRReservation", "greenSelect"); // エクスプレス予約サービス
-        buffer += outConditionSelect("shinkansenETicket", "whiteSelect"); // 新幹線eチケットサービス
+        buffer += outConditionSelect("JRReservation", "greenSelect"); // エクスプレス予約
+        buffer += outConditionSelect("shinkansenETicket", "whiteSelect"); // 新幹線eチケット
         buffer += outConditionSelect("ticketSystemType", "greenSelect"); // 乗車券計算のシステム
         buffer += outConditionSelect("preferredTicketOrder", "whiteSelect"); // 優先する乗車券の順序
         buffer += outConditionSelect("nikukanteiki", "greenSelect"); // ２区間定期の利用
@@ -948,27 +948,27 @@ var expGuiCondition = function (pObject, config) {
                         setValue("ticketSystemType", "ic");
                     }
                 } else if (eventIdList[1].toLowerCase() == String("studentDiscount").toLowerCase()) {
-                    // 学割乗車券とエクスプレス予約サービスは排他
+                    // 学割乗車券とエクスプレス予約は排他
                     if (getValue("studentDiscount") == "true" && getValue("JRReservation") != "none") {
                         setValue("JRReservation", "none");
-                        alert("学割乗車券とエクスプレス予約サービスを同時に有効にすることはできません。")
+                        alert("学割乗車券とエクスプレス予約を同時に有効にすることはできません。")
                     }
-                    // 学割乗車券と新幹線eチケットサービスは排他
+                    // 学割乗車券と新幹線eチケットは排他
                     if (getValue("studentDiscount") == "true" && getValue("shinkansenETicket") != "none") {
                         setValue("shinkansenETicket", "none");
-                        alert("学割乗車券と新幹線eチケットサービスを同時に有効にすることはできません。")
+                        alert("学割乗車券と新幹線eチケットを同時に有効にすることはできません。")
                     }
                 } else if (eventIdList[1].toLowerCase() == String("JRReservation").toLowerCase()) {
-                    // 学割乗車券とエクスプレス予約サービスは排他
+                    // 学割乗車券とエクスプレス予約は排他
                     if (getValue("JRReservation") != "none" && getValue("studentDiscount") == "true") {
                         setValue("studentDiscount", "false");
-                        alert("学割乗車券とエクスプレス予約サービスを同時に有効にすることはできません。")
+                        alert("学割乗車券とエクスプレス予約を同時に有効にすることはできません。")
                     }
                 } else if (eventIdList[1].toLowerCase() == String("shinkansenETicket").toLowerCase()) {
-                    // 学割乗車券とエクスプレス予約サービスは排他
+                    // 学割乗車券と新幹線eチケットは排他
                     if (getValue("shinkansenETicket") != "none" && getValue("studentDiscount") == "true") {
                         setValue("studentDiscount", "false");
-                        alert("学割乗車券と新幹線eチケットサービスを同時に有効にすることはできません。")
+                        alert("学割乗車券と新幹線eチケットを同時に有効にすることはできません。")
                     }
                 }
             }
@@ -1100,7 +1100,7 @@ var expGuiCondition = function (pObject, config) {
     }
 
     /**
-    * エクスプレス予約サービスのインデックスの桁数変換
+    * エクスプレス予約のインデックスの桁数変換
     */
     function getJRReservation() {      
         var selectedName = getValue("JRReservation");
@@ -1131,7 +1131,7 @@ var expGuiCondition = function (pObject, config) {
     }
 
     /**
-    * 新幹線eチケットサービスのインデックスの桁数変換
+    * 新幹線eチケットのインデックスの桁数変換
     */
    function getShinkansenETicket() {      
     var selectedName = getValue("shinkansenETicket");

--- a/expGuiCondition/expGuiCondition.js
+++ b/expGuiCondition/expGuiCondition.js
@@ -199,9 +199,9 @@ var expGuiCondition = function (pObject, config) {
         var tmpOption = new Array("計算する", "計算しない");
         var tmpValue = new Array("true", "false");
         tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
-        // JR予約サービス
+        // エクスプレス予約サービス
         var conditionId = "JRReservation";
-        var conditionLabel = "JR予約サービス";
+        var conditionLabel = "エクスプレス予約サービス";
         var tmpOption = new Array("適用しない","ＥＸ予約", "ＥＸ予約(ｅ特急券)", "ＥＸ予約(ＥＸ早特)", "ＥＸ予約(ＥＸ早特２１)", "ＥＸ予約(ＥＸグリーン早特)", "スマートＥＸ", "スマートＥＸ(ＥＸ早特)", "スマートＥＸ(ＥＸ早特２１)", "スマートＥＸ(ＥＸグリーン早特)");
         var tmpValue = new Array("none", "exYoyaku", "exETokkyu", "exHayatoku", "exHayatoku21", "exGreenHayatoku", "smartEx", "smartExHayatoku", "smartExHayatoku21", "smartExGreenHayatoku");
         tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
@@ -566,7 +566,7 @@ var expGuiCondition = function (pObject, config) {
         // 定期種別初期値
         buffer += outConditionRadio("teikiKind", "greenSelect");
         buffer += outSeparator("teikiKind");
-        // JR予約サービス
+        // エクスプレス予約サービス
         if (agent == 1 || agent == 2) {
             buffer += outConditionSelect("JRReservation");
         } else if (agent == 3) {
@@ -750,7 +750,7 @@ var expGuiCondition = function (pObject, config) {
         buffer += outConditionSelect("studentDiscount", "whiteSelect"); // 学割乗車券
         buffer += outConditionSelect("teikiKind", "greenSelect"); // 定期種別初期値
         buffer += outConditionSelect("JRSeasonalRate", "whiteSelect"); // JR季節料金
-        buffer += outConditionSelect("JRReservation", "greenSelect"); // JR予約サービス
+        buffer += outConditionSelect("JRReservation", "greenSelect"); // エクスプレス予約サービス
         buffer += outConditionSelect("shinkansenETicket", "whiteSelect"); // 新幹線eチケットサービス
         buffer += outConditionSelect("ticketSystemType", "greenSelect"); // 乗車券計算のシステム
         buffer += outConditionSelect("preferredTicketOrder", "whiteSelect"); // 優先する乗車券の順序
@@ -948,10 +948,10 @@ var expGuiCondition = function (pObject, config) {
                         setValue("ticketSystemType", "ic");
                     }
                 } else if (eventIdList[1].toLowerCase() == String("studentDiscount").toLowerCase()) {
-                    // 学割乗車券とJR予約サービスは排他
+                    // 学割乗車券とエクスプレス予約サービスは排他
                     if (getValue("studentDiscount") == "true" && getValue("JRReservation") != "none") {
                         setValue("JRReservation", "none");
-                        alert("学割乗車券とJR予約サービスを同時に有効にすることはできません。")
+                        alert("学割乗車券とエクスプレス予約サービスを同時に有効にすることはできません。")
                     }
                     // 学割乗車券と新幹線eチケットサービスは排他
                     if (getValue("studentDiscount") == "true" && getValue("shinkansenETicket") != "none") {
@@ -959,13 +959,13 @@ var expGuiCondition = function (pObject, config) {
                         alert("学割乗車券と新幹線eチケットサービスを同時に有効にすることはできません。")
                     }
                 } else if (eventIdList[1].toLowerCase() == String("JRReservation").toLowerCase()) {
-                    // 学割乗車券とJR予約サービスは排他
+                    // 学割乗車券とエクスプレス予約サービスは排他
                     if (getValue("JRReservation") != "none" && getValue("studentDiscount") == "true") {
                         setValue("studentDiscount", "false");
-                        alert("学割乗車券とJR予約サービスを同時に有効にすることはできません。")
+                        alert("学割乗車券とエクスプレス予約サービスを同時に有効にすることはできません。")
                     }
                 } else if (eventIdList[1].toLowerCase() == String("shinkansenETicket").toLowerCase()) {
-                    // 学割乗車券とJR予約サービスは排他
+                    // 学割乗車券とエクスプレス予約サービスは排他
                     if (getValue("shinkansenETicket") != "none" && getValue("studentDiscount") == "true") {
                         setValue("studentDiscount", "false");
                         alert("学割乗車券と新幹線eチケットサービスを同時に有効にすることはできません。")
@@ -1100,7 +1100,7 @@ var expGuiCondition = function (pObject, config) {
     }
 
     /**
-    * JR予約サービスのインデックスの桁数変換
+    * エクスプレス予約サービスのインデックスの桁数変換
     */
     function getJRReservation() {      
         var selectedName = getValue("JRReservation");

--- a/expGuiCondition/expGuiCondition.js
+++ b/expGuiCondition/expGuiCondition.js
@@ -199,16 +199,16 @@ var expGuiCondition = function (pObject, config) {
         var tmpOption = new Array("計算する", "計算しない");
         var tmpValue = new Array("true", "false");
         tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
-        // エクスプレス予約
+        // EX予約/スマートEX
         var conditionId = "JRReservation";
-        var conditionLabel = "エクスプレス予約";
+        var conditionLabel = "EX予約/スマートEX";
         var tmpOption = new Array("適用しない","ＥＸ予約", "ＥＸ予約(ｅ特急券)", "ＥＸ予約(ＥＸ早特)", "ＥＸ予約(ＥＸ早特２１)", "ＥＸ予約(ＥＸグリーン早特)", "スマートＥＸ", "スマートＥＸ(ＥＸ早特)", "スマートＥＸ(ＥＸ早特２１)", "スマートＥＸ(ＥＸグリーン早特)");
         var tmpValue = new Array("none", "exYoyaku", "exETokkyu", "exHayatoku", "exHayatoku21", "exGreenHayatoku", "smartEx", "smartExHayatoku", "smartExHayatoku21", "smartExGreenHayatoku");
         tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
         // 新幹線eチケット
         var conditionId = "shinkansenETicket";
         var conditionLabel = "新幹線eチケット";
-        var tmpOption = new Array("適用しない","新幹線eチケット");
+        var tmpOption = new Array("適用しない","新幹線ｅチケット");
         var tmpValue = new Array("none", "eTicket");
         tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
         // 航空運賃の指定
@@ -566,7 +566,7 @@ var expGuiCondition = function (pObject, config) {
         // 定期種別初期値
         buffer += outConditionRadio("teikiKind", "greenSelect");
         buffer += outSeparator("teikiKind");
-        // エクスプレス予約
+        // EX予約/スマートEX
         if (agent == 1 || agent == 2) {
             buffer += outConditionSelect("JRReservation");
         } else if (agent == 3) {
@@ -750,7 +750,7 @@ var expGuiCondition = function (pObject, config) {
         buffer += outConditionSelect("studentDiscount", "whiteSelect"); // 学割乗車券
         buffer += outConditionSelect("teikiKind", "greenSelect"); // 定期種別初期値
         buffer += outConditionSelect("JRSeasonalRate", "whiteSelect"); // JR季節料金
-        buffer += outConditionSelect("JRReservation", "greenSelect"); // エクスプレス予約
+        buffer += outConditionSelect("JRReservation", "greenSelect"); // EX予約/スマートEX
         buffer += outConditionSelect("shinkansenETicket", "whiteSelect"); // 新幹線eチケット
         buffer += outConditionSelect("ticketSystemType", "greenSelect"); // 乗車券計算のシステム
         buffer += outConditionSelect("preferredTicketOrder", "whiteSelect"); // 優先する乗車券の順序
@@ -948,10 +948,10 @@ var expGuiCondition = function (pObject, config) {
                         setValue("ticketSystemType", "ic");
                     }
                 } else if (eventIdList[1].toLowerCase() == String("studentDiscount").toLowerCase()) {
-                    // 学割乗車券とエクスプレス予約は排他
+                    // 学割乗車券とEX予約/スマートEXは排他
                     if (getValue("studentDiscount") == "true" && getValue("JRReservation") != "none") {
                         setValue("studentDiscount", "false");
-                        alert("学割乗車券とエクスプレス予約を同時に有効にすることはできません。")
+                        alert("学割乗車券とEX予約/スマートEXを同時に有効にすることはできません。")
                     }
                     // 学割乗車券と新幹線eチケットは排他
                     if (getValue("studentDiscount") == "true" && getValue("shinkansenETicket") != "none") {
@@ -959,10 +959,10 @@ var expGuiCondition = function (pObject, config) {
                         alert("学割乗車券と新幹線eチケットを同時に有効にすることはできません。")
                     }
                 } else if (eventIdList[1].toLowerCase() == String("JRReservation").toLowerCase()) {
-                    // 学割乗車券とエクスプレス予約は排他
+                    // 学割乗車券とEX予約/スマートEXは排他
                     if (getValue("JRReservation") != "none" && getValue("studentDiscount") == "true") {
                         setValue("JRReservation", "none");
-                        alert("学割乗車券とエクスプレス予約を同時に有効にすることはできません。")
+                        alert("学割乗車券とEX予約/スマートEXを同時に有効にすることはできません。")
                     }
                 } else if (eventIdList[1].toLowerCase() == String("shinkansenETicket").toLowerCase()) {
                     // 学割乗車券と新幹線eチケットは排他
@@ -1100,7 +1100,7 @@ var expGuiCondition = function (pObject, config) {
     }
 
     /**
-    * エクスプレス予約のインデックスの桁数変換
+    * EX予約/スマートEXのインデックスの桁数変換
     */
     function getJRReservation() {      
         var selectedName = getValue("JRReservation");

--- a/expGuiCondition/expGuiCondition.js
+++ b/expGuiCondition/expGuiCondition.js
@@ -4,7 +4,7 @@
  *  サンプルコード
  *  https://github.com/EkispertWebService/GUI
  *  
- *  Version:2018-05-28
+ *  Version:2020-10-12
  *  
  *  Copyright (C) Val Laboratory Corporation. All rights reserved.
  **/
@@ -64,7 +64,7 @@ var expGuiCondition = function (pObject, config) {
     // 変数郡
     // デフォルト探索条件
     var def_condition_t = "T3221233232319";
-    var def_condition_f = "F342112212000";
+    var def_condition_f = "F3421122120000";
     
     var def_condition_a = "A23121141";
     var def_sortType = "ekispert"; // デフォルトソート
@@ -204,6 +204,12 @@ var expGuiCondition = function (pObject, config) {
         var conditionLabel = "JR予約サービス";
         var tmpOption = new Array("適用しない","ＥＸ予約", "ＥＸ予約(ｅ特急券)", "ＥＸ予約(ＥＸ早特)", "ＥＸ予約(ＥＸ早特２１)", "ＥＸ予約(ＥＸグリーン早特)", "スマートＥＸ", "スマートＥＸ(ＥＸ早特)", "スマートＥＸ(ＥＸ早特２１)", "スマートＥＸ(ＥＸグリーン早特)");
         var tmpValue = new Array("none", "exYoyaku", "exETokkyu", "exHayatoku", "exHayatoku21", "exGreenHayatoku", "smartEx", "smartExHayatoku", "smartExHayatoku21", "smartExGreenHayatoku");
+        tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
+        // 新幹線eチケット
+        var conditionId = "shinkansenETicket";
+        var conditionLabel = "新幹線eチケットサービス";
+        var tmpOption = new Array("適用しない","新幹線eチケット");
+        var tmpValue = new Array("none", "eTicket");
         tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
         // 航空運賃の指定
         //var conditionId = "airFare";
@@ -567,6 +573,13 @@ var expGuiCondition = function (pObject, config) {
             buffer += outConditionRadio("JRReservation");
         }
         buffer += outSeparator("JRReservation");
+        // 新幹線eチケット
+        if (agent == 1 || agent == 2) {
+            buffer += outConditionSelect("shinkansenETicket");
+        } else if (agent == 3) {
+            buffer += outConditionRadio("shinkansenETicket");
+        }
+        buffer += outSeparator("shinkansenETicket");
         // JR季節料金
         buffer += outConditionRadio("JRSeasonalRate", "whiteSelect");
         buffer += outSeparator("JRSeasonalRate");
@@ -738,9 +751,10 @@ var expGuiCondition = function (pObject, config) {
         buffer += outConditionSelect("teikiKind", "greenSelect"); // 定期種別初期値
         buffer += outConditionSelect("JRSeasonalRate", "whiteSelect"); // JR季節料金
         buffer += outConditionSelect("JRReservation", "greenSelect"); // JR予約サービス
-        buffer += outConditionSelect("ticketSystemType", "whiteSelect"); // 乗車券計算のシステム
-        buffer += outConditionSelect("preferredTicketOrder", "greenSelect"); // 優先する乗車券の順序
-        buffer += outConditionSelect("nikukanteiki", "whiteSelect"); // ２区間定期の利用
+        buffer += outConditionSelect("shinkansenETicket", "whiteSelect"); // 新幹線eチケットサービス
+        buffer += outConditionSelect("ticketSystemType", "greenSelect"); // 乗車券計算のシステム
+        buffer += outConditionSelect("preferredTicketOrder", "whiteSelect"); // 優先する乗車券の順序
+        buffer += outConditionSelect("nikukanteiki", "greenSelect"); // ２区間定期の利用
         //buffer += outConditionSelect("includeInsurance", "greenSelect"); // 航空保険特別料金
         //  buffer += outConditionSelect("airFare");// 航空運賃の指定
         buffer += '</div>';
@@ -939,11 +953,22 @@ var expGuiCondition = function (pObject, config) {
                         setValue("JRReservation", "none");
                         alert("学割乗車券とJR予約サービスを同時に有効にすることはできません。")
                     }
+                    // 学割乗車券と新幹線eチケットサービスは排他
+                    if (getValue("studentDiscount") == "true" && getValue("shinkansenETicket") != "none") {
+                        setValue("shinkansenETicket", "none");
+                        alert("学割乗車券と新幹線eチケットサービスを同時に有効にすることはできません。")
+                    }
                 } else if (eventIdList[1].toLowerCase() == String("JRReservation").toLowerCase()) {
                     // 学割乗車券とJR予約サービスは排他
                     if (getValue("JRReservation") != "none" && getValue("studentDiscount") == "true") {
                         setValue("studentDiscount", "false");
                         alert("学割乗車券とJR予約サービスを同時に有効にすることはできません。")
+                    }
+                } else if (eventIdList[1].toLowerCase() == String("shinkansenETicket").toLowerCase()) {
+                    // 学割乗車券とJR予約サービスは排他
+                    if (getValue("shinkansenETicket") != "none" && getValue("studentDiscount") == "true") {
+                        setValue("studentDiscount", "false");
+                        alert("学割乗車券と新幹線eチケットサービスを同時に有効にすることはできません。")
                     }
                 }
             }
@@ -1106,6 +1131,21 @@ var expGuiCondition = function (pObject, config) {
     }
 
     /**
+    * 新幹線eチケットサービスのインデックスの桁数変換
+    */
+   function getShinkansenETicket() {      
+    var selectedName = getValue("shinkansenETicket");
+    switch(selectedName) {
+        case 'none':
+          return 0;
+        case 'eTicket':
+          return 1;
+        default:
+          return 0;
+    }
+}
+
+    /**
     * 探索条件をフォームにセットする
     */
     function setCondition(param1, param2, priceType, condition) {
@@ -1167,6 +1207,7 @@ var expGuiCondition = function (pObject, config) {
             } else {
                 setValue("JRReservation", 10);
             }
+            setValue("shinkansenETicket", parseInt(conditionList_f[13]));
             // 探索条件(A)
             setValue("useJR", parseInt(conditionList_a[1]));
             setValue("transfer", parseInt(conditionList_a[2]));
@@ -1276,6 +1317,7 @@ var expGuiCondition = function (pObject, config) {
         conditionList_f[10] = getValueIndex("preferredTicketOrder", parseInt(conditionList_f[10]));
         conditionList_f[11] = getJRReservation()[0];
         conditionList_f[12] = getJRReservation()[1];
+        conditionList_f[13] = getShinkansenETicket();
         // 探索条件(A)
         var conditionList_a = def_condition_a.split('');
         conditionList_a[1] = getValueIndex("useJR", parseInt(conditionList_a[1]));
@@ -1520,7 +1562,6 @@ var expGuiCondition = function (pObject, config) {
     this.CONDITON_SURCHARGEKIND = "surchargeKind";
     this.CONDITON_TEIKIKIND = "teikiKind";
     this.CONDITON_JRSEASONALRATE = "JRSeasonalRate";
-    this.CONDITON_JRRESERVATION = "JRReservation";
     this.CONDITON_STUDENTDISCOUNT = "studentDiscount";
     //this.CONDITON_AIRFARE = "airFare";
     //this.CONDITON_INCLUDEINSURANCE = "includeInsurance";


### PR DESCRIPTION
# 概要

* 探索条件において、『[新幹線eチケット](https://www.eki-net.com/top/jrticket/ic/)』を新たに選択できるようにしました。
* これにより、経路探索結果において、新幹線eチケットを使う場合の合計金額を表示できるようになります。

# 補足

* 新幹線eチケットサービスとエクスプレス予約サービスを区別するため、これまでの『JR予約サービス』表記していた部分を『エクスプレス予約サービス』に名称変更しました。
* PC・スマホ・タブレットで動作確認済みです。