### PR TITLE
2021年の祝日を反映しました

### DIFF
--- a/expGuiDateTime/expGuiDateTime.js
+++ b/expGuiDateTime/expGuiDateTime.js
@@ -661,7 +661,7 @@ var expGuiDateTime = function (pObject, config) {
         if (month == 1 && day == 1) { syuku = '元日'; }            //  1月 1日
         if (month == 2 && day == 11) { syuku = '建国記念の日'; }    //  2月11日
         if (year <= 2018 && month == 12 && day == 23) { syuku = '天皇誕生日'; } // 2018年まで
-        if (year >= 2020 && month == 2 && day == 23) { syuku = '天皇誕生日'; }     // 2021年から2月23日
+        if (year >= 2020 && month == 2 && day == 23) { syuku = '天皇誕生日'; }     // 2020年から2月23日
         if (month == 4 && day == 29 && year <= 2006) { syuku = 'みどりの日'; }      //  4月29日(2006年まで)
         if (month == 4 && day == 29 && year >= 2007) { syuku = '昭和の日'; }        //  4月29日(2007年から)
         if (month == 5 && day == 3) { syuku = '憲法記念日'; }      //  5月 3日

--- a/expGuiDateTime/expGuiDateTime.js
+++ b/expGuiDateTime/expGuiDateTime.js
@@ -660,7 +660,8 @@ var expGuiDateTime = function (pObject, config) {
         // その他の祝日
         if (month == 1 && day == 1) { syuku = '元日'; }            //  1月 1日
         if (month == 2 && day == 11) { syuku = '建国記念の日'; }    //  2月11日
-        if (year >= 2020 && month == 2 && day == 24) { syuku = '天皇誕生日'; }     // 2020年から2月24日
+        if (year == 2020 && month == 2 && day == 24) { syuku = '天皇誕生日'; }     // 2020年は2月24日(振替休日)
+        if (year >= 2021 && month == 2 && day == 23) { syuku = '天皇誕生日'; }     // 2021年から2月23日
         if (month == 4 && day == 29 && year <= 2006) { syuku = 'みどりの日'; }      //  4月29日(2006年まで)
         if (month == 4 && day == 29 && year >= 2007) { syuku = '昭和の日'; }        //  4月29日(2007年から)
         if (month == 5 && day == 3) { syuku = '憲法記念日'; }      //  5月 3日

--- a/expGuiDateTime/expGuiDateTime.js
+++ b/expGuiDateTime/expGuiDateTime.js
@@ -673,8 +673,11 @@ var expGuiDateTime = function (pObject, config) {
         if (year < 2003 && month == 9 && day == 15) { syuku = '敬老の日'; } //  9月15日(～2002)
         if (month == 8 && day == 11 && year >= 2016 && year != 2020) { syuku = '山の日'; } //  8月11日(2016年から) 2020年のみ、山の日は別の日となる
         if (year == 2020 && month == 7 && day == 23) { syuku = '海の日'; }      //  2020年7月23日
+        if (year == 2021 && month == 7 && day == 22) { syuku = '海の日'; }      //  2021年7月22日
         if (year == 2020 && month == 7 && day == 24) { syuku = 'スポーツの日'; }      //  2020年7月24日
+        if (year == 2021 && month == 7 && day == 23) { syuku = 'スポーツの日'; }      //  2021年7月23日
         if (year == 2020 && month == 8 && day == 10) { syuku = '山の日'; }      //  2020年8月10日
+        if (year == 2021 && month == 8 && day == 8) { syuku = '山の日'; }      //  2021年8月8日
 
         // 振替休日
         // (2007年から)「国民の祝日」が日曜日に当たるときは、その日後においてその日に最も近い「国民の祝日」でない日を休日とする。

--- a/expGuiDateTime/expGuiDateTime.js
+++ b/expGuiDateTime/expGuiDateTime.js
@@ -661,8 +661,7 @@ var expGuiDateTime = function (pObject, config) {
         if (month == 1 && day == 1) { syuku = '元日'; }            //  1月 1日
         if (month == 2 && day == 11) { syuku = '建国記念の日'; }    //  2月11日
         if (year <= 2018 && month == 12 && day == 23) { syuku = '天皇誕生日'; } // 2018年まで
-        if (year == 2020 && month == 2 && day == 24) { syuku = '天皇誕生日'; }     // 2020年は2月24日(振替休日)
-        if (year >= 2021 && month == 2 && day == 23) { syuku = '天皇誕生日'; }     // 2021年から2月23日
+        if (year >= 2020 && month == 2 && day == 23) { syuku = '天皇誕生日'; }     // 2021年から2月23日
         if (month == 4 && day == 29 && year <= 2006) { syuku = 'みどりの日'; }      //  4月29日(2006年まで)
         if (month == 4 && day == 29 && year >= 2007) { syuku = '昭和の日'; }        //  4月29日(2007年から)
         if (month == 5 && day == 3) { syuku = '憲法記念日'; }      //  5月 3日

--- a/expGuiDateTime/expGuiDateTime.js
+++ b/expGuiDateTime/expGuiDateTime.js
@@ -625,7 +625,7 @@ var expGuiDateTime = function (pObject, config) {
             // 第2月曜
             if (moncnt == 2) {
                 if (month == 1) { syuku = '成人の日'; }    // 1月
-                if (month == 10 && year != 2020) { // 2020年のみ、スポーツの日は固定の日になる
+                if (month == 10 && year != 2020 && year != 2021) { // 東京五輪開催に伴い、2020年および2021年はスポーツの日は固定の日になる
                     if (year < 2020) {
                         syuku = '体育の日';
                     } else {
@@ -635,7 +635,7 @@ var expGuiDateTime = function (pObject, config) {
             }
             // 第3月曜
             if (moncnt == 3) {
-                if (year >= 2003 && month == 7 && year != 2020) { syuku = '海の日'; }   // 7月(2003～)　2020年のみ、海の日は固定の日になる
+                if (year >= 2003 && month == 7 && year != 2020 && year != 2021) { syuku = '海の日'; }   // 7月(2003～)　2020年および2021年は、海の日は固定の日になる
                 if (year >= 2003 && month == 9) { syuku = '敬老の日'; } // 9月(2003～)
             }
         }
@@ -671,7 +671,7 @@ var expGuiDateTime = function (pObject, config) {
         if (month == 11 && day == 23) { syuku = '勤労感謝の日'; }   // 11月23日
         if (year < 2003 && month == 7 && day == 20) { syuku = '海の日'; }   // 7月20日(～2002)
         if (year < 2003 && month == 9 && day == 15) { syuku = '敬老の日'; } //  9月15日(～2002)
-        if (month == 8 && day == 11 && year >= 2016 && year != 2020) { syuku = '山の日'; } //  8月11日(2016年から) 2020年のみ、山の日は別の日となる
+        if (month == 8 && day == 11 && year >= 2016 && year != 2020 && year != 2021) { syuku = '山の日'; } //  8月11日(2016年から) 2020年および2021年は、山の日は別の日となる
         if (year == 2020 && month == 7 && day == 23) { syuku = '海の日'; }      //  2020年7月23日
         if (year == 2021 && month == 7 && day == 22) { syuku = '海の日'; }      //  2021年7月22日
         if (year == 2020 && month == 7 && day == 24) { syuku = 'スポーツの日'; }      //  2020年7月24日

--- a/expGuiDateTime/expGuiDateTime.js
+++ b/expGuiDateTime/expGuiDateTime.js
@@ -660,6 +660,7 @@ var expGuiDateTime = function (pObject, config) {
         // その他の祝日
         if (month == 1 && day == 1) { syuku = '元日'; }            //  1月 1日
         if (month == 2 && day == 11) { syuku = '建国記念の日'; }    //  2月11日
+        if (year <= 2018 && month == 12 && day == 23) { syuku = '天皇誕生日'; } // 2018年まで
         if (year == 2020 && month == 2 && day == 24) { syuku = '天皇誕生日'; }     // 2020年は2月24日(振替休日)
         if (year >= 2021 && month == 2 && day == 23) { syuku = '天皇誕生日'; }     // 2021年から2月23日
         if (month == 4 && day == 29 && year <= 2006) { syuku = 'みどりの日'; }      //  4月29日(2006年まで)
@@ -675,7 +676,6 @@ var expGuiDateTime = function (pObject, config) {
         if (year == 2020 && month == 7 && day == 23) { syuku = '海の日'; }      //  2020年7月23日
         if (year == 2020 && month == 7 && day == 24) { syuku = 'スポーツの日'; }      //  2020年7月24日
         if (year == 2020 && month == 8 && day == 10) { syuku = '山の日'; }      //  2020年8月10日
-        if (year <= 2018 && month == 12 && day == 23) { syuku = '天皇誕生日'; } // 2018年まで
 
         // 振替休日
         // (2007年から)「国民の祝日」が日曜日に当たるときは、その日後においてその日に最も近い「国民の祝日」でない日を休日とする。


### PR DESCRIPTION
## 概要

* 東京五輪開催に伴い、2021年の祝日を反映しました

## 変更内容

* 2021/07/19　平日に変更（例年の海の日）
* 2021/07/22　祝日に変更（海の日）
* 2021/07/23　祝日に変更（スポーツの日）東京五輪開会式
* 2021/08/08　祝日に変更（山の日）東京五輪閉会式
* 2021/08/09　祝日に変更（山の日の振替休日）
* 2021/08/11　平日に変更（例年の山の日）
* 2021/10/11　平日に変更（例年のスポーツの日）

## 備考

* 上記変更に加えて、天皇誕生日に誤りがあったので、2/24→2/23に修正いたしました

## 参考

* 内閣府が定める2021年の祝日：https://www8.cao.go.jp/chosei/shukujitsu/gaiyou.html#syukujitu