### PR TITLE
IE11の公式サポート終了に伴い推奨環境を更新しました。

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@
 
 |OS|バージョン|ブラウザ|備考|
 | --- | --- | --- | --- |
-| Windows | 10 | Microsoft Edge | 最新版のみ対応 |
-| MacOSX | 10.7以降 | Safari | 最新版のみ対応 |
-| Windows/Mac | - | FireFox | 最新版のみ対応 |
-| Windows/Mac | - | Chrome | 最新版のみ対応 |
+| Windows | 10 | Microsoft Edge | 最新版を推奨 |
+| MacOSX | 10.7以降 | Safari | 最新版を推奨 |
+| Windows/Mac | - | FireFox | 最新版を推奨 |
+| Windows/Mac | - | Chrome | 最新版を推奨 |
 | iOS | 11.0以降 | Safari | |
 | Android | 6.0以降 | Chrome | |
+
 ※ IE11は非推奨です。
 
 ## デモ

--- a/README.md
+++ b/README.md
@@ -64,17 +64,17 @@
 
 [Wiki](https://github.com/EkispertWebService/GUI/wiki)にてリファレンスやサンプルなどをご用意しております。
 
-## 対象環境
+## 推奨環境
 
 |OS|バージョン|ブラウザ|備考|
 | --- | --- | --- | --- |
-| Windows | 8.1 | IE11 | |
 | Windows | 10 | Microsoft Edge | 最新版のみ対応 |
 | MacOSX | 10.7以降 | Safari | 最新版のみ対応 |
 | Windows/Mac | - | FireFox | 最新版のみ対応 |
 | Windows/Mac | - | Chrome | 最新版のみ対応 |
 | iOS | 11.0以降 | Safari | |
 | Android | 6.0以降 | Chrome | |
+※ IE11は非推奨です。
 
 ## デモ
 


### PR DESCRIPTION
## 概要
2022年6月15日（日本時間 6月16日）の公式サポート終了に伴い、Internet Explorer 11を非推奨に変更しました。

## 備考
2022年6月16日に変更を適用予定です。