### PR TITLE
オフピーク定期券の探索条件と探索結果への表示に対応しました。

### DIFF
--- a/expGuiCondition/expGuiCondition.js
+++ b/expGuiCondition/expGuiCondition.js
@@ -64,8 +64,7 @@ var expGuiCondition = function (pObject, config) {
     // 変数郡
     // デフォルト探索条件
     var def_condition_t = "T3221233232319";
-    var def_condition_f = "F3421122120000";
-    
+    var def_condition_f = "F34211221200001";
     var def_condition_a = "A23121141";
     var def_sortType = "ekispert"; // デフォルトソート
     var def_priceType = "oneway"; // 片道運賃がデフォルト
@@ -235,6 +234,12 @@ var expGuiCondition = function (pObject, config) {
         var conditionId = "nikukanteiki";
         var conditionLabel = "２区間定期の利用";
         var tmpOption = new Array("利用する", "利用しない");
+        var tmpValue = new Array("true", "false");
+        tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
+        // オフピーク定期券
+        var conditionId = "offpeakTeiki";
+        var conditionLabel = "オフピーク定期券";
+        var tmpOption = new Array("計算する", "計算しない");
         var tmpValue = new Array("true", "false");
         tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
         // JR路線
@@ -591,7 +596,10 @@ var expGuiCondition = function (pObject, config) {
         buffer += outSeparator("preferredTicketOrder");
         // ２区間定期の利用
         buffer += outConditionRadio("nikukanteiki", "greenSelect");
-        //buffer += outSeparator("nikukanteiki");
+        buffer += outSeparator("nikukanteiki");
+        // オフピーク定期券
+        buffer += outConditionRadio("offpeakTeiki", "whiteSelect");
+        // buffer += outSeparator("offpeakTeiki");
         // 航空保険特別料金
         //buffer += outConditionRadio("includeInsurance", "whiteSelect");
         // 航空運賃の指定
@@ -755,6 +763,7 @@ var expGuiCondition = function (pObject, config) {
         buffer += outConditionSelect("ticketSystemType", "greenSelect"); // 乗車券計算のシステム
         buffer += outConditionSelect("preferredTicketOrder", "whiteSelect"); // 優先する乗車券の順序
         buffer += outConditionSelect("nikukanteiki", "greenSelect"); // ２区間定期の利用
+        buffer += outConditionSelect("offpeakTeiki", "whiteSelect"); // オフピーク定期券
         //buffer += outConditionSelect("includeInsurance", "greenSelect"); // 航空保険特別料金
         //  buffer += outConditionSelect("airFare");// 航空運賃の指定
         buffer += '</div>';
@@ -1208,6 +1217,7 @@ var expGuiCondition = function (pObject, config) {
                 setValue("JRReservation", 10);
             }
             setValue("shinkansenETicket", parseInt(conditionList_f[13]));
+            setValue("offpeakTeiki", parseInt(conditionList_f[14]));
             // 探索条件(A)
             setValue("useJR", parseInt(conditionList_a[1]));
             setValue("transfer", parseInt(conditionList_a[2]));
@@ -1318,6 +1328,7 @@ var expGuiCondition = function (pObject, config) {
         conditionList_f[11] = getJRReservation()[0];
         conditionList_f[12] = getJRReservation()[1];
         conditionList_f[13] = getShinkansenETicket();
+        conditionList_f[14] = getValueIndex("offpeakTeiki", parseInt(conditionList_f[14]));
         // 探索条件(A)
         var conditionList_a = def_condition_a.split('');
         conditionList_a[1] = getValueIndex("useJR", parseInt(conditionList_a[1]));
@@ -1567,6 +1578,7 @@ var expGuiCondition = function (pObject, config) {
     //this.CONDITON_INCLUDEINSURANCE = "includeInsurance";
     this.CONDITON_TICKETSYSTEMTYPE = "ticketSystemType";
     this.CONDITON_NIKUKANTEIKI = "nikukanteiki";
+    this.CONDITON_OFFPEAKTEIKI = "offpeakTeiki";
     this.CONDITON_USEJR = "useJR";
     this.CONDITON_TRANSFER = "transfer";
     this.CONDITON_EXPRESSSTARTINGSTATION = "expressStartingStation";

--- a/expGuiCourse/expGuiCourse.js
+++ b/expGuiCourse/expGuiCourse.js
@@ -2092,6 +2092,10 @@ var expGuiCourse = function (pObject, config) {
                             } else {
                                 buffer += appendRevisionStatusLineClass([teiki1List[j].RevisionStatus], num2String(parseInt(getTextValue(teiki1List[j].Oneway))) + '円', '');
                             }
+                            // オフピーク定期券の金額かどうかの判定
+                            if (teiki1List[j].offpeakTeiki == 'true') {
+                                buffer += '&nbsp;' + '[オフピーク]';
+                            }
                         } else {
                             buffer += '------円';
                         }
@@ -2102,6 +2106,10 @@ var expGuiCourse = function (pObject, config) {
                                 buffer += appendRevisionStatusLineClass([teiki3List[j].RevisionStatus], getTextValue(teiki3List[j].Name), '');
                             } else {
                                 buffer += appendRevisionStatusLineClass([teiki3List[j].RevisionStatus], num2String(parseInt(getTextValue(teiki3List[j].Oneway))) + '円', '');
+                            }
+                            // オフピーク定期券の金額かどうかの判定
+                            if (teiki3List[j].offpeakTeiki == 'true') {
+                                buffer += '&nbsp;' + '[オフピーク]';
                             }
                         } else {
                             buffer += '------円';
@@ -2114,6 +2122,10 @@ var expGuiCourse = function (pObject, config) {
                             } else {
                                 buffer += appendRevisionStatusLineClass([teiki6List[j].RevisionStatus], num2String(parseInt(getTextValue(teiki6List[j].Oneway))) + '円', '');
                             }
+                            // オフピーク定期券の金額かどうかの判定
+                            if (teiki6List[j].offpeakTeiki == 'true') {
+                                buffer += '&nbsp;' + '[オフピーク]';
+                            }
                         } else {
                             buffer += '------円';
                         }
@@ -2124,6 +2136,10 @@ var expGuiCourse = function (pObject, config) {
                                 buffer += appendRevisionStatusLineClass([teiki12List[j].RevisionStatus], getTextValue(teiki12List[j].Name), '');
                             } else {
                                 buffer += appendRevisionStatusLineClass([teiki12List[j].RevisionStatus], num2String(parseInt(getTextValue(teiki12List[j].Oneway))) + '円', '');
+                            }
+                            // オフピーク定期券の金額かどうかの判定
+                            if (teiki12List[j].offpeakTeiki == 'true') {
+                                buffer += '&nbsp;' + '[オフピーク]';
                             }
                         } else {
                             buffer += '------円';


### PR DESCRIPTION
## 概要
2023年3月発売予定の「オフピーク定期券」について、
「オフピーク定期券で計算する／計算しない」を指定する探索条件、
および探索結果の定期区間に「オフピーク定期券の金額かどうか」を表す表示を追加しました。

## イメージ
探索条件
<img width="30%" alt="スクリーンショット 2023-02-09 13 39 25" src="https://user-images.githubusercontent.com/2200910/217722738-29de5b98-fc84-4f4a-a350-3af580c8d3b9.png">
経路探索結果
<img width="30%" alt="スクリーンショット 2023-02-09 13 40 16" src="https://user-images.githubusercontent.com/2200910/217722762-8654da48-91cd-4143-9487-3d004d486e68.png">

## 動作確認
* PC・スマホ・タブレットで確認済みです。

## 備考
* 本ブランチはAPIでのリリースに合わせてマージ予定です。