### PR TITLE
経路表示パーツにオフピーク定期券利用時の計算モードの設定と取得の関数を追加しました。

### DIFF
--- a/expGuiCourse/expGuiCourse.js
+++ b/expGuiCourse/expGuiCourse.js
@@ -256,6 +256,9 @@ var expGuiCourse = function (pObject, config) {
                         case "assignteikiserializedata":
                             searchObj.setAssignTeikiSerializeData(tmpParam[1]);
                             break;
+                        case "offpeakteikimode":
+                            searchObj.setOffpeakTeikiMode(tmpParam[1]);
+                            break;
                         case "assignnikukanteikiindex":
                             searchObj.setAssignNikukanteikiIndex(tmpParam[1]);
                             break;
@@ -358,6 +361,9 @@ var expGuiCourse = function (pObject, config) {
             }
             if (typeof searchObj.getAssignTeikiSerializeData() != 'undefined') {
                 searchWord += "&assignTeikiSerializeData=" + encodeURIComponent(searchObj.getAssignTeikiSerializeData());
+            }
+            if (typeof searchObj.getOffpeakTeikiMode() != 'undefined') {
+                searchWord += "&offpeakTeikiMode=" + searchObj.getOffpeakTeikiMode();
             }
             if (typeof searchObj.getAssignNikukanteikiIndex() != 'undefined') {
                 searchWord += "&assignNikukanteikiIndex=" + searchObj.getAssignNikukanteikiIndex();
@@ -4485,6 +4491,7 @@ var expGuiCourse = function (pObject, config) {
         var assignRoute;
         var assignDetailRoute;
         var assignTeikiSerializeData;
+        var offpeakTeikiMode;
         var assignNikukanteikiIndex;
         var coupon;
         var bringAssignmentError;
@@ -4582,6 +4589,11 @@ var expGuiCourse = function (pObject, config) {
         function getAssignTeikiSerializeData() { return assignTeikiSerializeData; };
         this.setAssignTeikiSerializeData = setAssignTeikiSerializeData;
         this.getAssignTeikiSerializeData = getAssignTeikiSerializeData;
+        // offpeakTeikiMode設定
+        function setOffpeakTeikiMode(value) { offpeakTeikiMode = value; };
+        function getOffpeakTeikiMode() { return offpeakTeikiMode; };
+        this.setOffpeakTeikiMode = setOffpeakTeikiMode;
+        this.getOffpeakTeikiMode = getOffpeakTeikiMode;
         // AssignNikukanteikiIndex設定
         function setAssignNikukanteikiIndex(value) { assignNikukanteikiIndex = value; };
         function getAssignNikukanteikiIndex() { return assignNikukanteikiIndex; };

--- a/expGuiCourse/expGuiCourse.js
+++ b/expGuiCourse/expGuiCourse.js
@@ -4,7 +4,7 @@
  *  サンプルコード
  *  https://github.com/EkispertWebService/GUI
  *
- *  Version:2022-02-17
+ *  Version:2023-08-25
  *
  *  Copyright (C) Val Laboratory Corporation. All rights reserved.
  **/

--- a/sample/expSample.js
+++ b/sample/expSample.js
@@ -3,7 +3,7 @@
  *  サンプルコード
  *  https://github.com/EkispertWebService/GUI
  *  
- *  Version:2016-06-20
+ *  Version:2023-08-25
  *  
  *  Copyright (C) Val Laboratory Corporation. All rights reserved.
  **/
@@ -453,6 +453,12 @@ function search(callBack) {
         if (document.getElementById("passRoute")) {
             if (document.getElementById("passRoute").value != "") {
                 searchWord += '&assignDetailRoute=' + document.getElementById("passRoute").value;
+            }
+        }
+        // オフピーク定期券利用時の計算モードが存在する場合はセットする
+        if (document.getElementById("offpeakTeikiMode")) {
+            if (document.getElementById("offpeakTeikiMode").value != "") {
+                searchWord += '&offpeakTeikiMode=' + document.getElementById("offpeakTeikiMode").value;
             }
         }
         // 探索を実行


### PR DESCRIPTION
## 概要
* APIでのオフピーク定期券利用時の運賃計算への対応に伴い、
  * 経路表示パーツに、「オフピーク定期券利用時の計算モード（オフピーク時間帯利用として計算／ピーク時間帯利用として計算）」を設定する関数、取得する関数を追加しました。
  * サンプルコード（`expSample.js`）の探索ボタンの動作（`search()`）として、APIへのクエリパラメータにオフピーク定期券利用時の計算モードを追加する処理を加えました。
    * 利用するためには、HTMLに「オフピーク定期券利用時の計算モード」を選択させるUIを追加する必要があります。

## 関連
* 別途、Wikiのリファレンスにも今回追加した関数を追記する予定です。
  * リファレンス > 経路表示パーツ
* 別途、Wikiのサンプルにも「オフピーク定期券利用時の計算モード」を選択させるUIを加える予定です。
  * サンプル > 指定した定期券を利用する
  * サンプル > サンプルコード集の全ての機能を利用する

## 動作確認
* サンプルHTMLに「オフピーク定期券利用時の計算モード」を選択させるUIを追加し、PC・スマホ・タブレットで確認済みです。

## 備考
* 本ブランチはAPIでのリリースに合わせてマージ予定です。