### PR TITLE
定期券を利用するサンプルにオフピーク定期券の利用を設定するUIを追加しました。

### DIFF
--- a/sample/expGuiCourse.js
+++ b/sample/expGuiCourse.js
@@ -4,7 +4,7 @@
  *  サンプルコード
  *  https://github.com/EkispertWebService/GUI
  *
- *  Version:2022-02-17
+ *  Version:2023-08-25
  *
  *  Copyright (C) Val Laboratory Corporation. All rights reserved.
  **/
@@ -256,6 +256,9 @@ var expGuiCourse = function (pObject, config) {
                         case "assignteikiserializedata":
                             searchObj.setAssignTeikiSerializeData(tmpParam[1]);
                             break;
+                        case "offpeakteikimode":
+                            searchObj.setOffpeakTeikiMode(tmpParam[1]);
+                            break;
                         case "assignnikukanteikiindex":
                             searchObj.setAssignNikukanteikiIndex(tmpParam[1]);
                             break;
@@ -358,6 +361,9 @@ var expGuiCourse = function (pObject, config) {
             }
             if (typeof searchObj.getAssignTeikiSerializeData() != 'undefined') {
                 searchWord += "&assignTeikiSerializeData=" + encodeURIComponent(searchObj.getAssignTeikiSerializeData());
+            }
+            if (typeof searchObj.getOffpeakTeikiMode() != 'undefined') {
+                searchWord += "&offpeakTeikiMode=" + searchObj.getOffpeakTeikiMode();
             }
             if (typeof searchObj.getAssignNikukanteikiIndex() != 'undefined') {
                 searchWord += "&assignNikukanteikiIndex=" + searchObj.getAssignNikukanteikiIndex();
@@ -4485,6 +4491,7 @@ var expGuiCourse = function (pObject, config) {
         var assignRoute;
         var assignDetailRoute;
         var assignTeikiSerializeData;
+        var offpeakTeikiMode;
         var assignNikukanteikiIndex;
         var coupon;
         var bringAssignmentError;
@@ -4582,6 +4589,11 @@ var expGuiCourse = function (pObject, config) {
         function getAssignTeikiSerializeData() { return assignTeikiSerializeData; };
         this.setAssignTeikiSerializeData = setAssignTeikiSerializeData;
         this.getAssignTeikiSerializeData = getAssignTeikiSerializeData;
+        // offpeakTeikiMode設定
+        function setOffpeakTeikiMode(value) { offpeakTeikiMode = value; };
+        function getOffpeakTeikiMode() { return offpeakTeikiMode; };
+        this.setOffpeakTeikiMode = setOffpeakTeikiMode;
+        this.getOffpeakTeikiMode = getOffpeakTeikiMode;
         // AssignNikukanteikiIndex設定
         function setAssignNikukanteikiIndex(value) { assignNikukanteikiIndex = value; };
         function getAssignNikukanteikiIndex() { return assignNikukanteikiIndex; };

--- a/sample/expSample.js
+++ b/sample/expSample.js
@@ -3,7 +3,7 @@
  *  サンプルコード
  *  https://github.com/EkispertWebService/GUI
  *  
- *  Version:2016-06-20
+ *  Version:2023-08-25
  *  
  *  Copyright (C) Val Laboratory Corporation. All rights reserved.
  **/
@@ -449,10 +449,16 @@ function search(callBack) {
         searchWord += '&conditionDetail=' + conditionApp.getConditionDetail();
         // 会社名の出力をデフォルトにする
         searchWord += "&resultDetail=addCorporation";
-        //定期券が存在する場合はセットする
+        // 定期券が存在する場合はセットする
         if (document.getElementById("passRoute")) {
             if (document.getElementById("passRoute").value != "") {
                 searchWord += '&assignDetailRoute=' + document.getElementById("passRoute").value;
+            }
+        }
+        // オフピーク定期券利用時の計算モードが未指定でない場合はセットする
+        if (document.getElementById("offpeakTeikiMode")) {
+            if (document.getElementById("offpeakTeikiMode").value != "") {
+                searchWord += '&offpeakTeikiMode=' + document.getElementById("offpeakTeikiMode").value;
             }
         }
         // 探索を実行

--- a/sample/sample_all.html
+++ b/sample/sample_all.html
@@ -90,7 +90,7 @@
             return;
         }
         search();
-	}
+    }
 // -->
 </script>
 </head>

--- a/sample/sample_all.html
+++ b/sample/sample_all.html
@@ -48,6 +48,38 @@
             document.getElementById("passRoute").value = passRoute;
         }
     }
+
+    /**
+    * オフピーク定期券利用の選択
+    */
+    function changeUseOffpeakTeiki() {
+        // オフピーク定期券を利用する場合のみ、計算モードのセレクトボックスを有効化する
+        if (document.getElementById("use_offpeak_teiki").checked) {
+            document.getElementById("offpeak_teiki_mode").disabled = false;
+            document.getElementById("offpeakTeikiMode").value = document.getElementById("offpeak_teiki_mode").options.item(document.getElementById("offpeak_teiki_mode").selectedIndex).value;
+        } else {
+            document.getElementById("offpeak_teiki_mode").disabled = true;
+            document.getElementById("offpeakTeikiMode").value = "";
+        }
+    }
+
+    /**
+    * 定期を利用した探索実行
+    */
+    function searchWithTeiki(){
+        // セレクトボックスで指定したオフピーク定期券利用時の計算モードを利用する
+        if (document.getElementById("use_offpeak_teiki").checked) {
+            document.getElementById("offpeakTeikiMode").value = document.getElementById("offpeak_teiki_mode").options.item(document.getElementById("offpeak_teiki_mode").selectedIndex).value;
+        } else {
+            document.getElementById("offpeakTeikiMode").value = "";
+        }
+        // オフピーク定期券利用時の計算モードは定期が設定されている場合のみ設定できる
+        if (document.getElementById("passRoute").value == "" && document.getElementById("offpeakTeikiMode").value != "") {
+            alert("下記の項目を確認してください。\n利用する定期が未設定でオフピーク定期券を利用することはできません。");
+            return;
+        }
+        search();
+	}
 // -->
 </script>
 </head>
@@ -91,12 +123,29 @@
     <!-- 定期設定 -->
     <h3 class="exp_sample_header">定期経路</h3>
     <input class="exp_sample_teiki" type="text" id="passRoute" value="" readonly>
+    <br><br>
+
+    <!-- オフピーク定期券利用時の計算モードの設定 -->
+    <div class="exp_sample_title">
+        オフピーク定期券の利用
+    </div>
+    <div>
+        <input type="checkbox" id="use_offpeak_teiki" onchange="JavaScript:changeUseOffpeakTeiki();"/>
+        <label for="use_offpeak_teiki">オフピーク定期券を利用する</label>
+    </div>
+    <select id="offpeak_teiki_mode" class="exp_select" disabled>
+        <option value="offpeakTime">オフピーク時間帯</option>
+        <option value="peakTime">ピーク時間帯</option>
+    </select>
+
+    <!-- オフピーク定期券利用時の計算モードのパラメータ -->
+    <input type="hidden" id="offpeakTeikiMode" value="">
 
     <br><br>
 
     <!-- 探索実行ボタン -->
     <div class="exp_sample_btn_area">
-        <input class="exp_sample_btn" type="button" value="探索" onClick="Javascript:search();">
+        <input class="exp_sample_btn" type="button" value="探索" onClick="Javascript:searchWithTeiki();">
         <input class="exp_sample_btn" type="button" value="定期券を探索" onClick="Javascript:searchTeiki(selectCourse);">
         <input class="exp_sample_btn" type="button" value="定期券の払い戻し計算" onClick="Javascript:restoreTeikiRoute();">
     </div>

--- a/sample/sample_all.html
+++ b/sample/sample_all.html
@@ -64,9 +64,9 @@
     }
 
     /**
-    * 定期を利用した探索実行
+    * オフピーク定期券を利用するための設定
     */
-    function searchWithTeiki(){
+    function settingForOffpeakTeikiMode(){
         // セレクトボックスで指定したオフピーク定期券利用時の計算モードを利用する
         if (document.getElementById("use_offpeak_teiki").checked) {
             document.getElementById("offpeakTeikiMode").value = document.getElementById("offpeak_teiki_mode").options.item(document.getElementById("offpeak_teiki_mode").selectedIndex).value;
@@ -76,6 +76,17 @@
         // オフピーク定期券利用時の計算モードは定期が設定されている場合のみ設定できる
         if (document.getElementById("passRoute").value == "" && document.getElementById("offpeakTeikiMode").value != "") {
             alert("下記の項目を確認してください。\n利用する定期が未設定でオフピーク定期券を利用することはできません。");
+            return false;
+        }
+        return true;
+    }
+
+    /**
+    * 定期を利用した探索実行
+    */
+    function searchWithTeiki(){
+        // オフピーク定期券を利用するための設定
+        if (settingForOffpeakTeikiMode() == false) {
             return;
         }
         search();

--- a/sample/sample_teiki_use.html
+++ b/sample/sample_teiki_use.html
@@ -27,9 +27,10 @@
         }
     }
 
-	function searchWithTeiki(){
-        // セレクトボックスで指定した定期券を利用する
-        document.getElementById("passRoute").value = document.getElementById("teiki").options.item(document.getElementById("teiki").selectedIndex).value;
+    /**
+    * オフピーク定期券を利用するための設定
+    */
+    function settingForOffpeakTeikiMode(){
         // セレクトボックスで指定したオフピーク定期券利用時の計算モードを利用する
         if (document.getElementById("use_offpeak_teiki").checked) {
             document.getElementById("offpeakTeikiMode").value = document.getElementById("offpeak_teiki_mode").options.item(document.getElementById("offpeak_teiki_mode").selectedIndex).value;
@@ -39,6 +40,16 @@
         // オフピーク定期券利用時の計算モードは定期が設定されている場合のみ設定できる
         if (document.getElementById("passRoute").value == "" && document.getElementById("offpeakTeikiMode").value != "") {
             alert("下記の項目を確認してください。\n利用する定期が未設定でオフピーク定期券を利用することはできません。");
+            return false;
+        }
+        return true;
+    }
+
+	function searchWithTeiki(){
+        // セレクトボックスで指定した定期券を利用する
+        document.getElementById("passRoute").value = document.getElementById("teiki").options.item(document.getElementById("teiki").selectedIndex).value;
+        // オフピーク定期券を利用するための設定
+        if (settingForOffpeakTeikiMode() == false) {
             return;
         }
         search();

--- a/sample/sample_teiki_use.html
+++ b/sample/sample_teiki_use.html
@@ -45,7 +45,7 @@
         return true;
     }
 
-	function searchWithTeiki(){
+    function searchWithTeiki(){
         // セレクトボックスで指定した定期券を利用する
         document.getElementById("passRoute").value = document.getElementById("teiki").options.item(document.getElementById("teiki").selectedIndex).value;
         // オフピーク定期券を利用するための設定
@@ -53,7 +53,7 @@
             return;
         }
         search();
-	}
+    }
 // -->
 </script>
 </head>

--- a/sample/sample_teiki_use.html
+++ b/sample/sample_teiki_use.html
@@ -18,9 +18,29 @@
 <!--
     var key = "rnwfzKX4rvNVZYat";
 
+    function changeUseOffpeakTeiki() {
+        // オフピーク定期券を利用する場合のみ、計算モードのセレクトボックスを有効化する
+        if (document.getElementById("use_offpeak_teiki").checked) {
+            document.getElementById("offpeak_teiki_mode").disabled = false;
+        } else {
+            document.getElementById("offpeak_teiki_mode").disabled = true;
+        }
+    }
+
 	function searchWithTeiki(){
         // セレクトボックスで指定した定期券を利用する
         document.getElementById("passRoute").value = document.getElementById("teiki").options.item(document.getElementById("teiki").selectedIndex).value;
+        // セレクトボックスで指定したオフピーク定期券利用時の計算モードを利用する
+        if (document.getElementById("use_offpeak_teiki").checked) {
+            document.getElementById("offpeakTeikiMode").value = document.getElementById("offpeak_teiki_mode").options.item(document.getElementById("offpeak_teiki_mode").selectedIndex).value;
+        } else {
+            document.getElementById("offpeakTeikiMode").value = "";
+        }
+        // オフピーク定期券利用時の計算モードは定期が設定されている場合のみ設定できる
+        if (document.getElementById("passRoute").value == "" && document.getElementById("offpeakTeikiMode").value != "") {
+            alert("下記の項目を確認してください。\n利用する定期が未設定でオフピーク定期券を利用することはできません。");
+            return;
+        }
         search();
 	}
 // -->
@@ -58,6 +78,22 @@
 
     <!-- 定期控除のパラメータ -->
     <input type="hidden" id="passRoute" value="">
+
+    <!-- オフピーク定期券利用時の計算モードの設定 -->
+    <div class="exp_sample_title">
+        オフピーク定期券の利用
+    </div>
+    <div>
+        <input type="checkbox" id="use_offpeak_teiki" onchange="JavaScript:changeUseOffpeakTeiki();"/>
+        <label for="use_offpeak_teiki">オフピーク定期券を利用する</label>
+    </div>
+    <select id="offpeak_teiki_mode" class="exp_select" disabled>
+        <option value="offpeakTime">オフピーク時間帯</option>
+        <option value="peakTime">ピーク時間帯</option>
+    </select>
+
+    <!-- オフピーク定期券利用時の計算モードのパラメータ -->
+    <input type="hidden" id="offpeakTeikiMode" value="">
 
     <!-- 探索実行ボタン -->
     <div class="exp_sample_btn_area">


### PR DESCRIPTION
## 概要
* APIでのオフピーク定期券利用時の運賃計算への対応に伴い、別ブランチにてGUIの経路表示パーツに「オフピーク定期券利用時の計算モード（オフピーク時間帯利用として計算／ピーク時間帯利用として計算）」を設定する関数、取得する関数を追加します。
  * 関連: https://github.com/EkispertWebService/GUI/pull/50
* これに伴い、Wikiのサンプルに「オフピーク定期券の利用」という項目で「オフピーク定期券利用時の計算モード」を選択させるUIを追加しました。
  * サンプル > 指定した定期券を利用する（`sample_teiki_use.html`）
  * サンプル > サンプルコード集の全ての機能を利用する（`sample_all.html`）

## 仕様
* 「オフピーク定期券の利用」項目
  * 「オフピーク定期券を利用する」チェックボックスの初期状態は未チェックです。
    * 「利用する定期」をオフピーク定期券ではなく、通常の定期券として利用します。
  * 「オフピーク定期券を利用する」チェックボックスにチェックを入れると、計算モード（オフピーク時間帯／ピーク時間帯）のセレクトボックスが操作可能になります。
    * 「利用する定期」をオフピーク定期券として、選択した計算モードで利用します。
  * 「利用する定期」項目で定期が未設定の状態、かつ「オフピーク定期券を利用する」チェックボックスにチェックを入れて「探索」ボタンをクリックするとエラーメッセージを表示します。

## イメージ
### 指定した定期券を利用するサンプル
探索画面の初期表示
![sample_teiki_use_1_no_use_offpeak_teiki](https://github.com/EkispertWebService/GUI/assets/2200910/652d763d-c20c-415e-8db8-60d8f00f2d73)

定期を**通常の定期券**として利用した探索結果
![sample_teiki_use_2_no_use_offpeak_teiki_result](https://github.com/EkispertWebService/GUI/assets/2200910/9789f64d-73e1-4ac2-9d4f-eb59d6a0a108)

探索画面で「オフピーク定期券の利用」にチェックを入れる
![sample_teiki_use_3_use_offpeak_teiki](https://github.com/EkispertWebService/GUI/assets/2200910/5c8612b5-6553-4ce0-b6cb-4e122027a399)

定期を**オフピーク定期券**として**オフピーク時間帯**に利用した探索結果
![sample_teiki_use_4_use_offpeak_teiki_offpeak_time_result](https://github.com/EkispertWebService/GUI/assets/2200910/925e62da-134d-4d9c-a776-649815541f66)

定期を**オフピーク定期券**として**ピーク時間帯**に利用した探索結果
![sample_teiki_use_5_use_offpeak_teiki_peak_time_result](https://github.com/EkispertWebService/GUI/assets/2200910/f14a9c8e-511b-4d2b-9e10-f0dd8b540ac7)

## 動作確認
* PC・スマホ・タブレットで確認済みです。

## 備考
* 本ブランチはAPIでのリリースに合わせてマージ予定です。