### PR TITLE
EX予約/スマートEXの新商品「EX早特28ワイド」に対応しました。

### DIFF
--- a/expGuiCondition/expGuiCondition.js
+++ b/expGuiCondition/expGuiCondition.js
@@ -201,8 +201,8 @@ var expGuiCondition = function (pObject, config) {
         // EX予約/スマートEX
         var conditionId = "JRReservation";
         var conditionLabel = "EX予約/スマートEX";
-        var tmpOption = new Array("適用しない","ＥＸ予約", "ＥＸ予約(ｅ特急券)", "ＥＸ予約(ＥＸ早特)", "ＥＸ予約(ＥＸ早特２１)", "ＥＸ予約(ＥＸグリーン早特)", "ＥＸ予約(ＥＸ早特２８)", "スマートＥＸ", "スマートＥＸ(ＥＸ早特)", "スマートＥＸ(ＥＸ早特２１)", "スマートＥＸ(ＥＸグリーン早特)", "スマートＥＸ(ＥＸ早特２８)");
-        var tmpValue = new Array("none", "exYoyaku", "exETokkyu", "exHayatoku", "exHayatoku21", "exGreenHayatoku", "exHayatoku28", "smartEx", "smartExHayatoku", "smartExHayatoku21", "smartExGreenHayatoku", "smartExHayatoku28");
+        var tmpOption = new Array("適用しない","ＥＸ予約", "ＥＸ予約(ｅ特急券)", "ＥＸ予約(ＥＸ早特)", "ＥＸ予約(ＥＸ早特２１)", "ＥＸ予約(ＥＸ早特２８)", "ＥＸ予約(ＥＸグリーン早特)", "スマートＥＸ", "スマートＥＸ(ＥＸ早特)", "スマートＥＸ(ＥＸ早特２１)", "スマートＥＸ(ＥＸ早特２８)", "スマートＥＸ(ＥＸグリーン早特)");
+        var tmpValue = new Array("none", "exYoyaku", "exETokkyu", "exHayatoku", "exHayatoku21", "exHayatoku28", "exGreenHayatoku", "smartEx", "smartExHayatoku", "smartExHayatoku21", "smartExHayatoku28", "smartExGreenHayatoku");
         tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
         // 新幹線eチケット
         var conditionId = "shinkansenETicket";

--- a/expGuiCondition/expGuiCondition.js
+++ b/expGuiCondition/expGuiCondition.js
@@ -4,7 +4,7 @@
  *  サンプルコード
  *  https://github.com/EkispertWebService/GUI
  *  
- *  Version:2020-10-12
+ *  Version:2023-09-20
  *  
  *  Copyright (C) Val Laboratory Corporation. All rights reserved.
  **/
@@ -201,8 +201,8 @@ var expGuiCondition = function (pObject, config) {
         // EX予約/スマートEX
         var conditionId = "JRReservation";
         var conditionLabel = "EX予約/スマートEX";
-        var tmpOption = new Array("適用しない","ＥＸ予約", "ＥＸ予約(ｅ特急券)", "ＥＸ予約(ＥＸ早特)", "ＥＸ予約(ＥＸ早特２１)", "ＥＸ予約(ＥＸグリーン早特)", "スマートＥＸ", "スマートＥＸ(ＥＸ早特)", "スマートＥＸ(ＥＸ早特２１)", "スマートＥＸ(ＥＸグリーン早特)");
-        var tmpValue = new Array("none", "exYoyaku", "exETokkyu", "exHayatoku", "exHayatoku21", "exGreenHayatoku", "smartEx", "smartExHayatoku", "smartExHayatoku21", "smartExGreenHayatoku");
+        var tmpOption = new Array("適用しない","ＥＸ予約", "ＥＸ予約(ｅ特急券)", "ＥＸ予約(ＥＸ早特)", "ＥＸ予約(ＥＸ早特２１)", "ＥＸ予約(ＥＸグリーン早特)", "ＥＸ予約(ＥＸ早特２８)", "スマートＥＸ", "スマートＥＸ(ＥＸ早特)", "スマートＥＸ(ＥＸ早特２１)", "スマートＥＸ(ＥＸグリーン早特)", "スマートＥＸ(ＥＸ早特２８)");
+        var tmpValue = new Array("none", "exYoyaku", "exETokkyu", "exHayatoku", "exHayatoku21", "exGreenHayatoku", "exHayatoku28", "smartEx", "smartExHayatoku", "smartExHayatoku21", "smartExGreenHayatoku", "smartExHayatoku28");
         tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
         // 新幹線eチケット
         var conditionId = "shinkansenETicket";
@@ -1126,6 +1126,8 @@ var expGuiCondition = function (pObject, config) {
               return [4, 0];
             case 'exGreenHayatoku':
               return [5, 0];
+            case 'exHayatoku28':
+              return [6, 0];
             case 'smartEx':
               return [0, 1];
             case 'smartExHayatoku':
@@ -1134,6 +1136,8 @@ var expGuiCondition = function (pObject, config) {
               return [0, 3];
             case 'smartExGreenHayatoku':
               return [0, 4];
+            case 'smartExHayatoku28':
+              return [0, 5];
             default:
               return [0, 0];
         }
@@ -1207,14 +1211,14 @@ var expGuiCondition = function (pObject, config) {
             setValue("preferredTicketOrder", parseInt(conditionList_f[10]));
             if (conditionList_f.length >= 12) {
                 if ( parseInt(conditionList_f[11]) > 0 ) {
-                    setValue("JRReservation", 10 - parseInt(conditionList_f[11]));
+                    setValue("JRReservation", 12 - parseInt(conditionList_f[11]));
                 } else if ( parseInt(conditionList_f[12]) > 0 ) {
-                    setValue("JRReservation", 10 - ( parseInt(conditionList_f[12]) + 5) );
+                    setValue("JRReservation", 12 - ( parseInt(conditionList_f[12]) + 6) );
                 } else {
-                    setValue("JRReservation", 10);
+                    setValue("JRReservation", 12);
                 }
             } else {
-                setValue("JRReservation", 10);
+                setValue("JRReservation", 12);
             }
             setValue("shinkansenETicket", parseInt(conditionList_f[13]));
             setValue("offpeakTeiki", parseInt(conditionList_f[14]));


### PR DESCRIPTION
## 概要
* 2023年9月30日、JR東海、JR西日本、JR九州より、東海道・山陽・九州新幹線の「EXサービス」の新たな早特商品として、「EX早特28ワイド」が発売されます。
* これを受け、「駅すぱあと」および「駅すぱあとWebサービス」でも対応を行います。
* 本ブランチは、「駅すぱあとWebサービス」のAPIでの対応に伴う、GUIサンプルへの対応になります。
  * 探索条件パーツ（expGuiCondition） > 運賃タブ > EX予約/スマートEX のセレクトボックスに下記の2つを追加しました。
    * `ＥＸ予約(ＥＸ早特２８)`
    * `スマートＥＸ(ＥＸ早特２８)`
  * EX予約/スマートEX として `ＥＸ早特２８` を選択して探索を行うと、経路表示パーツでは `ＥＸ早特２８` が適用できる場合には割引が考慮された結果が表示されます。

## 画面イメージ
EX予約/スマートEX の探索条件
![sample_condition_ex_hayatoku28](https://github.com/EkispertWebService/GUI/assets/2200910/7464a577-d679-4bff-90dc-45bf154d4873)

`ＥＸ予約(ＥＸ早特２８)` を選択して、 `ＥＸ予約(ＥＸ早特２８)` が適用された探索結果
![sample_result_ex_hayatoku28](https://github.com/EkispertWebService/GUI/assets/2200910/3cb3d011-eb58-443e-b309-a5305023831b)

`スマートＥＸ(ＥＸ早特２８)` を選択して、 `スマートＥＸ(ＥＸ早特２８)` が適用された探索結果
![sample_result_smart_ex_hayatoku28](https://github.com/EkispertWebService/GUI/assets/2200910/32369801-6b42-41df-9375-04aa8993bcd2)

## 動作確認
* PC・スマホ・タブレットで確認済みです。

## 備考
* 本ブランチはAPIでのリリースに合わせてマージ予定です。