### PR TITLE
サンプルページをHTTPSに対応しました。

### DIFF
--- a/sample/basic.html
+++ b/sample/basic.html
@@ -22,6 +22,7 @@ var mapApp = new expGuiMap(document.getElementById("map"),{configure : {
                                                           navi      : true
                                                         }
                                                       });
+mapApp.setConfigure("ssl", true);
 mapApp.dispMap("tokyo");
 // -->
 </script>

--- a/sample/click.html
+++ b/sample/click.html
@@ -15,6 +15,7 @@
 <script type="text/javascript">
 <!--
 var mapApp = new expGuiMap(document.getElementById("map"));
+mapApp.setConfigure("ssl", true);
 mapApp.dispMap("tokyo");
 mapApp.bind('click',onStationClick);
 

--- a/sample/couponList.html
+++ b/sample/couponList.html
@@ -23,6 +23,7 @@ var coupon;
 function init(){
   // 回数券情報
   coupon = new expGuiCoupon();
+  coupon.setConfigure("ssl", true);
 }
 
 /*

--- a/sample/courseCoupon.html
+++ b/sample/courseCoupon.html
@@ -49,7 +49,7 @@ function search(){
 /*
  * 経路の取得
  */
- function searchCoupon(){
+function searchCoupon(){
   var couponDetailElement = document.getElementById("couponDetail");
   if(couponDetailElement && couponDetailElement.options.length > 0 && couponDetailElement.selectedIndex != -1){
     // 探索条件を設定

--- a/sample/courseCoupon.html
+++ b/sample/courseCoupon.html
@@ -49,14 +49,15 @@ function search(){
 /*
  * 経路の取得
  */
-function searchCoupon(){
-  if(document.getElementById("couponDetail")){
+ function searchCoupon(){
+  var couponDetailElement = document.getElementById("couponDetail");
+  if(couponDetailElement && couponDetailElement.options.length > 0 && couponDetailElement.selectedIndex != -1){
     // 探索条件を設定
     var searchObject = couponResult.createSearchInterface();
     // 発着地を設定
     searchObject.setViaList("東京:新横浜");
     // 回数券を設定
-    var couponName = document.getElementById("couponDetail").options.item(document.getElementById("couponDetail").selectedIndex).value;
+    var couponName = couponDetailElement.options.item(couponDetailElement.selectedIndex).value;
     searchObject.setCoupon(couponName);
     // 探索実行
     couponResult.search(searchObject);

--- a/sample/courseCoupon.html
+++ b/sample/courseCoupon.html
@@ -27,12 +27,15 @@ var couponResult;
 function init(){
   // 回数券情報
   coupon = new expGuiCoupon();
+  coupon.setConfigure("ssl", true);
   // 経路探索
   resultApp = new expGuiCourse(document.getElementById("course"));
+  resultApp.setConfigure("ssl", true);
   resultApp.setConfigure("PriceChangeRefresh",true);
   resultApp.bind("change",changeCourse);
   // 回数券利用時の経路
   couponResult = new expGuiCourse(document.getElementById("courseCoupon"));
+  couponResult.setConfigure("ssl", true);
 }
 
 /*

--- a/sample/courseCoupon.html
+++ b/sample/courseCoupon.html
@@ -43,7 +43,7 @@ function init(){
  */
 function search(){
   // 探索実行
-  resultApp.search("viaList=東京:新大阪&searchType="+ resultApp.SEARCHTYPE_PLAIN,resultApp.PRICE_ONEWAY,setResult);
+  resultApp.search("viaList=東京:新横浜&searchType="+ resultApp.SEARCHTYPE_PLAIN,resultApp.PRICE_ONEWAY,setResult);
 }
 
 /*
@@ -54,7 +54,7 @@ function searchCoupon(){
     // 探索条件を設定
     var searchObject = couponResult.createSearchInterface();
     // 発着地を設定
-    searchObject.setViaList("東京:新大阪");
+    searchObject.setViaList("東京:新横浜");
     // 回数券を設定
     var couponName = document.getElementById("couponDetail").options.item(document.getElementById("couponDetail").selectedIndex).value;
     searchObject.setCoupon(couponName);

--- a/sample/courseTimeTable.html
+++ b/sample/courseTimeTable.html
@@ -31,10 +31,13 @@ var resultApp;//経路表示パーツ
 function init(){
   // 駅時刻表
   courseStationTimeTable = new expGuiStationTimeTable(document.getElementById("stationTimetable"));
+  courseStationTimeTable.setConfigure("ssl", true);
   // 区間時刻表
   courseSectionTimeTable = new expGuiSectionTimeTable(document.getElementById("sectionTimetable"));
+  courseSectionTimeTable.setConfigure("ssl", true);
   // 経路探索
   resultApp = new expGuiCourse(document.getElementById("course"));
+  resultApp.setConfigure("ssl", true);
 }
 
 /*

--- a/sample/dataVersion.html
+++ b/sample/dataVersion.html
@@ -23,6 +23,7 @@ var version;
 function init(){
   // 駅情報
   version = new expGuiVersion();
+  version.setConfigure("ssl", true);
 }
 
 /*

--- a/sample/divided.html
+++ b/sample/divided.html
@@ -27,8 +27,10 @@ var priceType;
 function init(){
   // 分割計算
   divided = new expGuiDivided();
+  divided.setConfigure("ssl", true);
   // 経路探索
   resultApp = new expGuiCourse(document.getElementById("course"));
+  resultApp.setConfigure("ssl", true);
   resultApp.bind("change",changeCourse);
 }
 

--- a/sample/event.html
+++ b/sample/event.html
@@ -15,6 +15,7 @@
 <script type="text/javascript">
 <!--
 var mapApp = new expGuiMap(document.getElementById("map"));
+mapApp.setConfigure("ssl", true);
 mapApp.dispMap("tokyo");
 mapApp.bind('click',onStationClick);
 

--- a/sample/event2.html
+++ b/sample/event2.html
@@ -23,6 +23,7 @@ var mapApp = new expGuiMap(document.getElementById("map"),{configure : {
                                                           change    : true
                                                         }
                                                       });
+mapApp.setConfigure("ssl", true);
 mapApp.dispMap("tokyo");
 mapApp.bind('click',onStationClick);
 

--- a/sample/expSample.js
+++ b/sample/expSample.js
@@ -31,6 +31,7 @@ function init() {
     // 日付入力パーツ初期化
     if (document.getElementById("dateTime")) {
         dateTimeApp = new expGuiDateTime(document.getElementById("dateTime"));
+        dateTimeApp.setConfigure("ssl", true);
         dateTimeApp.dispDateTime();
         // クッキーから情報を復元する
         if (getCookie("searchType") != "") {
@@ -45,6 +46,7 @@ function init() {
     // 駅名入力パーツ#1初期化
     if (document.getElementById("station1")) {
         stationApp1 = new expGuiStation(document.getElementById("station1"));
+        stationApp1.setConfigure("ssl", true);
         if (typeof apiURL != 'undefined') {
             stationApp1.setConfigure("apiURL", apiURL);
         }
@@ -60,6 +62,7 @@ function init() {
     // 駅名入力パーツ#2初期化
     if (document.getElementById("station2")) {
         stationApp2 = new expGuiStation(document.getElementById("station2"));
+        stationApp2.setConfigure("ssl", true);
         if (typeof apiURL != 'undefined') {
             stationApp2.setConfigure("apiURL", apiURL);
         }
@@ -75,6 +78,7 @@ function init() {
     // 駅名入力パーツ#3初期化
     if (document.getElementById("station3")) {
         stationApp3 = new expGuiStation(document.getElementById("station3"));
+        stationApp3.setConfigure("ssl", true);
         if (typeof apiURL != 'undefined') {
             stationApp3.setConfigure("apiURL", apiURL);
         }
@@ -90,6 +94,7 @@ function init() {
     // 駅名入力パーツ#4初期化
     if (document.getElementById("station4")) {
         stationApp4 = new expGuiStation(document.getElementById("station4"));
+        stationApp4.setConfigure("ssl", true);
         if (typeof apiURL != 'undefined') {
             stationApp4.setConfigure("apiURL", apiURL);
         }
@@ -105,6 +110,7 @@ function init() {
     // 駅名入力パーツ#5初期化
     if (document.getElementById("station5")) {
         stationApp5 = new expGuiStation(document.getElementById("station5"));
+        stationApp5.setConfigure("ssl", true);
         if (typeof apiURL != 'undefined') {
             stationApp5.setConfigure("apiURL", apiURL);
         }
@@ -120,6 +126,7 @@ function init() {
     // 駅名入力パーツ#6初期化
     if (document.getElementById("station6")) {
         stationApp6 = new expGuiStation(document.getElementById("station6"));
+        stationApp6.setConfigure("ssl", true);
         if (typeof apiURL != 'undefined') {
             stationApp6.setConfigure("apiURL", apiURL);
         }
@@ -139,6 +146,7 @@ function init() {
     // 探索条件パーツ初期化
     if (document.getElementById("condition")) {
         conditionApp = new expGuiCondition(document.getElementById("condition"));
+        conditionApp.setConfigure("ssl", true);
         conditionApp.dispCondition();
         if (getCookie("answerCount") != "" && getCookie("sort") != "" && getCookie("priceType") != "" && getCookie("conditionDetail") != "") {
             conditionApp.setCondition(getCookie("answerCount"), getCookie("sort"), getCookie("priceType"), getCookie("conditionDetail"));
@@ -151,6 +159,7 @@ function init() {
     // 経路表示パーツ初期化
     if (document.getElementById("result")) {
         resultApp = new expGuiCourse(document.getElementById("result"));
+        resultApp.setConfigure("ssl", true);
         if (typeof apiURL != 'undefined') {
             resultApp.setConfigure("apiURL", apiURL);
         }
@@ -174,6 +183,7 @@ function init() {
         document.getElementById("repay_start").value = String(now.getFullYear()) + (now.getMonth() < 9 ? "0" : "") + String(now.getMonth() + 1) + (now.getDate() < 10 ? "0" : "") + String(now.getDate());
         document.getElementById("repay_repayment").value = String(now.getFullYear()) + (now.getMonth() < 9 ? "0" : "") + String(now.getMonth() + 1) + (now.getDate() < 10 ? "0" : "") + String(now.getDate());
         repaymentApp = new expGuiRepayment(document.getElementById("repayment"));
+        repaymentApp.setConfigure("ssl", true);
         if (typeof apiURL != 'undefined') {
             repaymentApp.setConfigure("apiURL", apiURL);
         }
@@ -188,6 +198,7 @@ function init() {
     stationApp1.setStation("高円寺");
 
     stationInfoApp = new expGuiStationInfo();
+    stationInfoApp.setConfigure("ssl", true);
     if (typeof apiURL != 'undefined') {
         stationInfoApp.setConfigure("apiURL", apiURL);
     }
@@ -198,6 +209,7 @@ function init() {
         initStationInfo();
     }
     railApp = new expGuiRail();
+    railApp.setConfigure("ssl", true);
     if (typeof apiURL != 'undefined') {
         railApp.setConfigure("apiURL", apiURL);
     }

--- a/sample/landmarkCourse.html
+++ b/sample/landmarkCourse.html
@@ -27,9 +27,12 @@ var resultApp;// 経路表示パーツ
 function init(){
   // 地点情報
   fromLandmark = new expGuiLandmark();
+  fromLandmark.setConfigure("ssl", true);
   toLandmark = new expGuiLandmark();
+  toLandmark.setConfigure("ssl", true);
   // 経路探索
   resultApp = new expGuiCourse(document.getElementById("course"));
+  resultApp.setConfigure("ssl", true);
 }
 
 /*

--- a/sample/mark.html
+++ b/sample/mark.html
@@ -15,6 +15,7 @@ var app;
 
 function onLoad() {
     app = new expGuiMap(document.getElementById("map"));
+    app.setConfigure("ssl", true);
     app.dispMapStation(22828,'jpnx4',onDispMapStation);
 }
 

--- a/sample/powerful.html
+++ b/sample/powerful.html
@@ -24,6 +24,7 @@
                                                           navi      : true
                                                         }
                                                       });
+                app.setConfigure("ssl", true);
                 // 東京(22828)を中心とした全域400％(jpnx4)の路線図を表示します
                 app.dispMapStation(22828,'jpnx4',onDispMapStation);
                 // クリックイベントを設定します

--- a/sample/railInfo.html
+++ b/sample/railInfo.html
@@ -23,6 +23,7 @@ var rail;
 function init(){
   // 路線情報
   rail = new expGuiRail();
+  rail.setConfigure("ssl", true);
 }
 
 /*

--- a/sample/repayment.html
+++ b/sample/repayment.html
@@ -26,9 +26,11 @@ var resultApp;// 経路表示パーツ
 function init(){
   // 払い戻し計算
   repayment = new expGuiRepayment(document.getElementById("repayment"));
+  repayment.setConfigure("ssl", true);
   repayment.bind('change',changeRepay);
   // 計算用の経路探索
   resultApp = new expGuiCourse(document.getElementById("teikiResult"));
+  resultApp.setConfigure("ssl", true);
 }
 
 /*

--- a/sample/sectionTimeTable.html
+++ b/sample/sectionTimeTable.html
@@ -24,6 +24,7 @@ var sectionTimeTable;
 function init(){
   // 区間時刻表
   sectionTimeTable = new expGuiSectionTimeTable(document.getElementById("sectionTimetable"))
+  sectionTimeTable.setConfigure("ssl", true);
   sectionTimeTable.bind("click",setTime);
 }
 

--- a/sample/stationInfo.html
+++ b/sample/stationInfo.html
@@ -23,6 +23,7 @@ var station;
 function init(){
   // 駅情報
   station = new expGuiStationInfo();
+  station.setConfigure("ssl", true);
   station.setConfigure("type",station.TYPE_TRAIN);
   station.setConfigure("corporationBind","ＪＲ");
 }

--- a/sample/stationRange.html
+++ b/sample/stationRange.html
@@ -23,6 +23,7 @@ var stationRange;
 function init(){
   // 範囲探索
   stationRange = new expGuiRange();
+  stationRange.setConfigure("ssl", true);
 }
 
 /*

--- a/sample/stationTimeTable.html
+++ b/sample/stationTimeTable.html
@@ -24,6 +24,7 @@ var stationTimetable;
 function init(){
   // 駅時刻表
   stationTimetable = new expGuiStationTimeTable(document.getElementById("stationTimetable"));
+  stationTimetable.setConfigure("ssl", true);
   stationTimetable.bind("click",setTime);
 }
 

--- a/sample/table.html
+++ b/sample/table.html
@@ -21,6 +21,7 @@
 <script language="JavaScript">
 <!--
 var mapApp = new expGuiMap(document.getElementById("map"));
+mapApp.setConfigure("ssl", true);
 mapApp.dispMap("tokyo");
 // -->
 </script>

--- a/sample/trainTimeTable.html
+++ b/sample/trainTimeTable.html
@@ -27,9 +27,11 @@ var stationTimetable;// 列車時刻表パーツ
 function init(){
   // 列車時刻表
   trainTimeTable = new expGuiTrainTimeTable(document.getElementById("trainTimetable"))
+  trainTimeTable.setConfigure("ssl", true);
   trainTimeTable.bind("click",setTime);
   // 駅時刻表の出力
   stationTimetable = new expGuiStationTimeTable(document.getElementById("stationTimetable"));
+  stationTimetable.setConfigure("ssl", true);
   stationTimetable.bind("click",viewTrainTimeTable);
   var stationName = document.getElementById("stationName").value;
   var lineCode = 1;

--- a/sample/xmlCourse.html
+++ b/sample/xmlCourse.html
@@ -26,8 +26,10 @@ var expTools;
 function init(){
   // ツール
   expTools = new expGuiTools();
+  expTools.setConfigure("ssl", true);
   // 経路探索
   resultApp = new expGuiCourse(document.getElementById("result"));
+  resultApp.setConfigure("ssl", true);
 }
 
 /*


### PR DESCRIPTION
## 概要
* ページをHTTPS(SSL)で利用したい場合は、SSL暗号化通信をオンに設定する必要があります。
* READMEのデモに記載のサンプルページのリンクを開くと、HTTPSになることで通信ができず動作を確認することができないページがありました。
* そのため、SSL暗号化通信の設定がなかったすべてのサンプルページの各GUIコンポーネントに、 `setConfigure("ssl", true);` を追加しました。

## 動作確認
* 本リポジトリをForkして、本ブランチと同じ変更をGitHub Pagesにデプロイし、README > デモ の各サンプルページが正常に動作することを確認済みです。
  * https://github.com/ayumihashimoto/GUI?tab=readme-ov-file#デモ ※あとで消す
* masterブランチにマージ後に、あらためて各サンプルページの動作確認を行います。

## その他
* 回数券を利用した経路探索のサンプルページについて、経路で利用できる回数券がなくなっていたため、ついでに経路を変更しました。（ 97b39a00c5e0d451b578be3f1a73f4ffc2755cf5 ）