### PR TITLE
EX予約/スマートEXの新商品「EX早特1」に対応しました。

### DIFF
--- a/expGuiCondition/expGuiCondition.js
+++ b/expGuiCondition/expGuiCondition.js
@@ -4,7 +4,7 @@
  *  サンプルコード
  *  https://github.com/EkispertWebService/GUI
  *  
- *  Version:2023-09-20
+ *  Version:2024-03-19
  *  
  *  Copyright (C) Val Laboratory Corporation. All rights reserved.
  **/
@@ -201,8 +201,8 @@ var expGuiCondition = function (pObject, config) {
         // EX予約/スマートEX
         var conditionId = "JRReservation";
         var conditionLabel = "EX予約/スマートEX";
-        var tmpOption = new Array("適用しない","ＥＸ予約", "ＥＸ予約(ｅ特急券)", "ＥＸ予約(ＥＸ早特)", "ＥＸ予約(ＥＸ早特２１)", "ＥＸ予約(ＥＸ早特２８)", "ＥＸ予約(ＥＸグリーン早特)", "スマートＥＸ", "スマートＥＸ(ＥＸ早特)", "スマートＥＸ(ＥＸ早特２１)", "スマートＥＸ(ＥＸ早特２８)", "スマートＥＸ(ＥＸグリーン早特)");
-        var tmpValue = new Array("none", "exYoyaku", "exETokkyu", "exHayatoku", "exHayatoku21", "exHayatoku28", "exGreenHayatoku", "smartEx", "smartExHayatoku", "smartExHayatoku21", "smartExHayatoku28", "smartExGreenHayatoku");
+        var tmpOption = new Array("適用しない","ＥＸ予約", "ＥＸ予約(ｅ特急券)", "ＥＸ予約(ＥＸ早特)", "ＥＸ予約(ＥＸ早特１)", "ＥＸ予約(ＥＸ早特２１)", "ＥＸ予約(ＥＸ早特２８)", "ＥＸ予約(ＥＸグリーン早特)", "スマートＥＸ", "スマートＥＸ(ＥＸ早特)", "スマートＥＸ(ＥＸ早特１)", "スマートＥＸ(ＥＸ早特２１)", "スマートＥＸ(ＥＸ早特２８)", "スマートＥＸ(ＥＸグリーン早特)");
+        var tmpValue = new Array("none", "exYoyaku", "exETokkyu", "exHayatoku", "exHayatoku1", "exHayatoku21", "exHayatoku28", "exGreenHayatoku", "smartEx", "smartExHayatoku", "smartExHayatoku1", "smartExHayatoku21", "smartExHayatoku28", "smartExGreenHayatoku");
         tmp_conditionObject[conditionId.toLowerCase()] = addCondition(conditionLabel, tmpOption, tmpValue);
         // 新幹線eチケット
         var conditionId = "shinkansenETicket";
@@ -1128,6 +1128,8 @@ var expGuiCondition = function (pObject, config) {
               return [5, 0];
             case 'exHayatoku28':
               return [6, 0];
+            case 'exHayatoku1':
+              return [7, 0];
             case 'smartEx':
               return [0, 1];
             case 'smartExHayatoku':
@@ -1138,6 +1140,8 @@ var expGuiCondition = function (pObject, config) {
               return [0, 4];
             case 'smartExHayatoku28':
               return [0, 5];
+            case 'smartExHayatoku1':
+              return [0, 6];
             default:
               return [0, 0];
         }
@@ -1211,14 +1215,14 @@ var expGuiCondition = function (pObject, config) {
             setValue("preferredTicketOrder", parseInt(conditionList_f[10]));
             if (conditionList_f.length >= 12) {
                 if ( parseInt(conditionList_f[11]) > 0 ) {
-                    setValue("JRReservation", 12 - parseInt(conditionList_f[11]));
+                    setValue("JRReservation", 14 - parseInt(conditionList_f[11]));
                 } else if ( parseInt(conditionList_f[12]) > 0 ) {
-                    setValue("JRReservation", 12 - ( parseInt(conditionList_f[12]) + 6) );
+                    setValue("JRReservation", 14 - ( parseInt(conditionList_f[12]) + 7) );
                 } else {
-                    setValue("JRReservation", 12);
+                    setValue("JRReservation", 14);
                 }
             } else {
-                setValue("JRReservation", 12);
+                setValue("JRReservation", 14);
             }
             setValue("shinkansenETicket", parseInt(conditionList_f[13]));
             setValue("offpeakTeiki", parseInt(conditionList_f[14]));


### PR DESCRIPTION
## 概要
* 2024年3月16日乗車分より、「EXサービス」の新たな早特商品として、「EX早特1」が発売されます。
* これを受け、「駅すぱあと」および「駅すぱあと API」でも対応を行います。
* 本ブランチは、「駅すぱあと API」での対応に伴う、GUIサンプルへの対応になります。
  * 探索条件パーツ（expGuiCondition） > 運賃タブ > EX予約/スマートEX のセレクトボックスに下記の2つを追加しました。
    * `ＥＸ予約(ＥＸ早特１)`
    * `スマートＥＸ(ＥＸ早特１)`
  * EX予約/スマートEX として `ＥＸ早特１` を選択して探索を行うと、経路表示パーツでは `ＥＸ早特１` が適用できる場合には割引が考慮された結果が表示されます。

## 画面イメージ
EX予約/スマートEX の探索条件
<img width="644" alt="sample_condition_ex_hayatoku1" src="https://github.com/EkispertWebService/GUI/assets/2200910/d73d2c18-b5af-4688-afe5-4c59d8213777">

`ＥＸ予約(ＥＸ早特１)` を選択して、 `ＥＸ予約(ＥＸ早特１)` が適用された探索結果
<img width="804" alt="sample_result_ex_hayatoku1" src="https://github.com/EkispertWebService/GUI/assets/2200910/c773faeb-81d7-4c59-b1c8-292ccefd07c7">

`スマートＥＸ(ＥＸ早特１)` を選択して、 `スマートＥＸ(ＥＸ早特１)` が適用された探索結果
<img width="803" alt="sample_result_smart_ex_hayatoku1 png" src="https://github.com/EkispertWebService/GUI/assets/2200910/c54fec05-ee61-42d8-a0e9-e739767f8c89">

## 動作確認
* PC・スマホ・タブレットで確認済みです。

## 備考
* 本ブランチはAPIでのリリースに合わせてマージ予定です。