### PR TITLE
expGuiCondition.jsの「定期種別初期値(teikiKind)」の初期値の不具合を修正しました

### DIFF
--- a/expGuiCondition/expGuiCondition.js
+++ b/expGuiCondition/expGuiCondition.js
@@ -1204,7 +1204,9 @@ var expGuiCondition = function (pObject, config) {
             // 13:固定
             // 探索条件(F)
             setValue("surchargeKind", parseInt(conditionList_f[1]));
-            setValue("teikiKind", parseInt(conditionList_f[2]));
+            // 定期種別初期値については、「通勤:(value=3)、通学（大学）:(value=1)、通学（高校）:(value=2)、通学（中学）:(value=4)」の順でラジオボタンの要素を表示したい
+            // そのため、setRadioIndex()ではなくsetRadio()を使用して初期値を設定する必要があるため、parseInt()は行わない
+            setValue("teikiKind", conditionList_f[2]);
             setValue("JRSeasonalRate", parseInt(conditionList_f[3]));
             setValue("studentDiscount", parseInt(conditionList_f[4]));
             //  setValue("airFare",parseInt(conditionList_f[5]));(固定)

--- a/expGuiCondition/expGuiCondition.js
+++ b/expGuiCondition/expGuiCondition.js
@@ -4,7 +4,7 @@
  *  サンプルコード
  *  https://github.com/EkispertWebService/GUI
  *  
- *  Version:2024-03-19
+ *  Version:2024-06-21
  *  
  *  Copyright (C) Val Laboratory Corporation. All rights reserved.
  **/

--- a/expGuiCondition/expGuiCondition.js
+++ b/expGuiCondition/expGuiCondition.js
@@ -64,7 +64,7 @@ var expGuiCondition = function (pObject, config) {
     // 変数郡
     // デフォルト探索条件
     var def_condition_t = "T3221233232319";
-    var def_condition_f = "F34211221200001";
+    var def_condition_f = "F33211221200001";
     var def_condition_a = "A23121141";
     var def_sortType = "ekispert"; // デフォルトソート
     var def_priceType = "oneway"; // 片道運賃がデフォルト


### PR DESCRIPTION
## 経緯

- 探索詳細条件のGUIパーツにおいて、「定期種別初期値」の項目のラジオボタンの初期値が、期待した値にならない不具合が見つかりました。
- 具体例： [`def_condition_f`](https://github.com/EkispertWebService/GUI/blob/e9396a3da919e3463ba3ec0455e7580305026165/expGuiCondition/expGuiCondition.js#L67) という変数の2桁目で `3`（ `通勤` に対応する値）を設定しても、探索詳細条件のGUIパーツ内の「定期種別初期値」のラジオボタンは `通勤` ではなく `通学 (大学)` が初期値で選択されてしまう

## 原因

- 探索詳細条件のGUIパーツ内の「定期種別初期値」は、要素を「通勤:(value=3)、通学（大学）:(value=1)、通学（高校）:(value=2)、通学（中学）:(value=4)」の順に表示するようにしています。
つまり、「定期種別初期値」の初期値を設定する場合は、各要素のインデックスの値ではなく、各要素の `value` 属性の値を確認する必要があります。
- しかし、実装の不備により、 [`setValue("teikiKind", parseInt(conditionList_f[2]))`](https://github.com/EkispertWebService/GUI/blob/e9396a3da919e3463ba3ec0455e7580305026165/expGuiCondition/expGuiCondition.js#L1207) のように `parseInt()` が実行されていた影響で、 [`setRadio()`](https://github.com/EkispertWebService/GUI/blob/e9396a3da919e3463ba3ec0455e7580305026165/expGuiCondition/expGuiCondition.js#L1278-L1284) ではなく [`setRadioIndex()`](https://github.com/EkispertWebService/GUI/blob/e9396a3da919e3463ba3ec0455e7580305026165/expGuiCondition/expGuiCondition.js#L1272-L1274) が結果的に呼び出されることになり、 `value` 属性の値ではなくインデックスの値を使って初期値が設定されてしまい、不具合が発生していました。

## 修正内容

`teikiKind` の `setValue()` において、 `parseInt()` を実行しないように修正しました。

## 備考

下記コードの部分は、暗黙的で分かりづらいため、根本的な処理の見直しを今後行ってもいいかもしれません。

- `parseInt()` を実行する／しないによって、 `setRadio()` ／ `setRadioIndex()` のいずれの関数が呼び出されるかに影響する点
- `setRadioIndex()` の処理内容（ラジオボタンの要素数からvalueの値を減算している処理）