### PR TITLE
expGuiCourseについて、探索結果が空だった場合に表示結果が切り替わらない問題を修正しました

### DIFF
--- a/expGuiCourse/expGuiCourse.js
+++ b/expGuiCourse/expGuiCourse.js
@@ -573,23 +573,30 @@ var expGuiCourse = function (pObject, config) {
             }
             // 経路表示
             viewResult();
-            // 表示する
-            document.getElementById(baseId + ':course').style.display = "block";
-            // 一度だけコールバックする
-            if (typeof callbackFunction == 'function') {
-                if (typeof result == 'undefined') {
-                    // 探索結果オブジェクトがない場合
-                    document.getElementById(baseId + ':course').style.display = "none";
+            if (typeof result == 'undefined') {
+                // 探索結果オブジェクトがない場合
+                document.getElementById(baseId + ':course').style.display = "none";
+                if (typeof callbackFunction == 'function') {
                     callbackFunction(false);
-                } else if (typeof result.ResultSet.Course == 'undefined') {
-                    // 探索結果が取得できていない場合
-                    document.getElementById(baseId + ':course').style.display = "none";
-                    callbackFunction(false);
-                } else {
-                    // 探索完了
-                    callbackFunction(true);
+                    callbackFunction = undefined;
                 }
-                callbackFunction = undefined;
+            } else if (typeof result.ResultSet.Course == 'undefined') {
+                // 探索結果が取得できていない場合
+                document.getElementById(baseId + ':course').style.display = "none";
+                if (typeof callbackFunction == 'function') {
+                    // 一度だけコールバックする
+                    callbackFunction(false);
+                    callbackFunction = undefined;
+                }
+            } else {
+                // 探索完了
+                // 表示する
+                document.getElementById(baseId + ':course').style.display = "block";
+                if (typeof callbackFunction == 'function') {
+                    // 一度だけコールバックする
+                    callbackFunction(true);
+                    callbackFunction = undefined;
+                }
             }
         }
     }


### PR DESCRIPTION
# 概要

[mixwayの経路検索可視化ツール](https://docs-mixway.ekispert.jp/tools/visualUrl.html)にて`expGuiCourse`の`setResult`メソッドを利用しており、一部修正したい挙動があったためプルリクエストを作成しました。

mixway APIは経路検索結果がない場合に以下のような形のレスポンスを返します。

```json
{
  "ResultSet": {
    "apiVersion": "1.0.0.0",
    "engineVersion": ""
  }
}
```

こうした探索結果が返却された場合に、探索結果の表示が更新されず、1つ前の探索結果が表示されたままになってしまう問題を修正いたしました。

# 変更点

探索結果の表示/非表示を切り替える部分（`document.getElementById(baseId + ':course').style.display = "none";`）の条件分岐を修正しました。
従来は`typeof callbackFunction == 'function'`の場合のみ非表示にする処理が走っていましたが、こちらの条件にかかわらず`display`が`none`になるようにしました。

# 動作確認

ローカルでサンプルを実行して動作確認済みです。
また、概要で説明した点については、以下のHTMLを用いて正常な挙動になっていることを確認済みです。

```html
<!--検証用HTML-->
<!DOCTYPE html>
<html lang="ja">
<head>
  <script src="../expGuiCourse/expGuiCourse.js"></script>
  <link rel="stylesheet" href="../expGuiCourse/expCss/expGuiCourse.css">
</head>
<body>
  <textarea id="input" placeholder="探索結果JSONを貼り付け"></textarea>
  <button id="button">表示</button>
  <div id="result"></div>
  <script type="module">
    const resultApp = new expGuiCourse(document.getElementById("result"));

    document.getElementById("button").addEventListener("click", () => {
      resultApp.setResult(document.getElementById("input").value)
    })
  </script>
</body>
</html>
```

検証手順は以下のとおりです。

1. 入力欄に`/search/cource/extreme`の正常なレスポンスを貼り付け、探索結果が表示される
2. 入力欄に空の探索結果のJSONを貼り付け、探索結果が表示されなくなることを確認（従来は古い探索結果が表示されたままになっていました。）

以上、急ぎのものではないため、お手隙の際に確認いただけますと幸いです。