### PR TITLE
運賃改定未対応時の文言を修正しました

### DIFF
--- a/expGuiCourse/expGuiCourse.js
+++ b/expGuiCourse/expGuiCourse.js
@@ -1143,7 +1143,7 @@ var expGuiCourse = function (pObject, config) {
         }
         if (salesTaxRateIsNotSupported) {
             buffer += '<div class="exp_fareRevisionStatus">';
-            buffer += '赤色の金額は、消費税率変更に未対応です。';
+            buffer += '赤色の金額は、改定前運賃です。';
             buffer += '</div>';
         }
         // ソートを行う
@@ -2602,7 +2602,7 @@ var expGuiCourse = function (pObject, config) {
         if (priceViewFlag == "oneway" || priceViewFlag == "round") {
             if (salesTaxRateIsNotSupported) {
                 buffer += '<div class="exp_fareRevisionStatus exp_clearfix">';
-                buffer += '赤色の金額は、消費税率変更に未対応です。';
+                buffer += '赤色の金額は、改定前運賃です。';
                 buffer += '</div>';
             }
 
@@ -2615,7 +2615,7 @@ var expGuiCourse = function (pObject, config) {
         } else if (priceViewFlag == "teiki") {
             if (Teiki1SummarySalesTaxRateIsNotSupported || Teiki3SummarySalesTaxRateIsNotSupported || Teiki6SummarySalesTaxRateIsNotSupported || Teiki12SummarySalesTaxRateIsNotSupported) {
                 buffer += '<div class="exp_fareRevisionStatus exp_clearfix">';
-                buffer += '赤色の金額は、消費税率変更に未対応です。';
+                buffer += '赤色の金額は、改定前運賃です。';
                 buffer += '</div>';
             }
 


### PR DESCRIPTION
## 概要

駅すぱあと APIの経路探索結果のレスポンスの`ResultSet / Course / Price / fareRevisionStatus`の仕様が次のように変わります。これに伴い文言を修正しました。

- **`ResultSet / Course / Price / fareRevisionStatus`が示す状態**
  - 変更前: その金額が消費税率変更に対応しているかどうか
  - 変更後: その金額が（消費税率変更に限らず）運賃改定に対応しているかどうか
- **`ResultSet / Course / Price / fareRevisionStatus`が`salesTaxRateIsNotSupported`である場合の金額の状態**
  - 変更前: 「消費税率変更に未対応」
  - 変更後: 「改定前運賃」

## 動作確認

文言のみの修正のため、ソースコードの動作に影響はありません。