### PR TITLE
fix: GitHub Actionsのワークフローの依存アクションのバージョンを最新化しました。

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -30,16 +30,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
         # 各デモページにアクセスキーを設定する（デモページの各htmlファイルには、アクセスキーを直接書かないようにしている）
       - name: Set EWS access key
         run: sed -i 's/YOUR_ACCESS_KEY/${{secrets.EWS_ACCESS_KEY}}/g' ./sample/*.html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
-          path: '.'
+          path: "."
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 概要

GitHub Actionsで使用しているアクションのバージョンを最新に更新しました。これにより、ワークフローの失敗が解消します。

## 背景

2025年1月30日以降、actions/upload-artifact@v3が使用不可となっており、GitHub Actionsのワークフローが失敗する状態になっていました。

- 参考：[Deprecation Notice (reminder): v3 of the artifact actions 📣 (updated) · community · Discussion #142581](https://github.com/orgs/community/discussions/142581)
- 失敗したワークフローの例：<https://github.com/EkispertWebService/GUI/actions/runs/14236703170>

## 変更内容

各アクションのバージョンを最新化しました。

- `actions/checkout` : `v3` → `v4`
- `actions/configure-pages` : `v3` → `v5`
- `actions/upload-pages-artifact` : `v2` → `v3`
- `actions/deploy-pages` : `v2` → `v4`

## 動作確認

このリポジトリをforkして作成したリポジトリの方で、このプルリクと同様の修正を行い、動作確認を行いました。

1. Settings > Pages > Source を、「GitHub Actions」に変更
1. Settings > secrets and variables > Actions > Repository secrets に`EWS_ACCESS_KEY`を設定
1. Forkしたリポジトリで修正をmasterにpush
1. ワークフローが正常に動作することを確認（<https://github.com/obikosato/GUI/actions/runs/14261230543>）
1. GitHub Pages（<https://obikosato.github.io/GUI/sample/sample_simple.html>）でサンプルの動作を確認

### 関連リンク

- GitHub ActionsによるGitHub Pagesの更新について: https://github.com/EkispertWebService/GUI/pull/52
